### PR TITLE
fix: network reliability improvements

### DIFF
--- a/examples/fanout/worker.py
+++ b/examples/fanout/worker.py
@@ -20,7 +20,7 @@ class Parent:
         for i in range(100):
             results.append(
                 (
-                    await context.spawn_workflow(
+                    await context.aio.spawn_workflow(
                         "Child", {"a": str(i)}, key=f"child{i}"
                     )
                 ).result()

--- a/hatchet_sdk/clients/dispatcher.py
+++ b/hatchet_sdk/clients/dispatcher.py
@@ -283,7 +283,6 @@ class ActionListenerImpl(WorkerActionListener):
             current_time - self.last_connection_attempt
             > DEFAULT_ACTION_LISTENER_RETRY_INTERVAL
         ):
-            print("RESETTING RETRIES!!!")
             self.retries = 0
 
         if self.retries > DEFAULT_ACTION_LISTENER_RETRY_COUNT:

--- a/hatchet_sdk/connection.py
+++ b/hatchet_sdk/connection.py
@@ -28,14 +28,27 @@ def new_conn(config, aio=False):
 
     strat = grpc if not aio else grpc.aio
 
+    channel_options = [
+        ("grpc.keepalive_time_ms", 10 * 1000),
+        ("grpc.keepalive_timeout_ms", 60 * 1000),
+        ("grpc.client_idle_timeout_ms", 60 * 1000),
+        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.keepalive_permit_without_calls", 1),
+    ]
+
     if config.tls_config.tls_strategy == "none":
         conn = strat.insecure_channel(
             target=config.host_port,
+            options=channel_options,
         )
     else:
+        channel_options.append(
+            ("grpc.ssl_target_name_override", config.tls_config.server_name)
+        )
+
         conn = strat.secure_channel(
             target=config.host_port,
             credentials=credentials,
-            options=[("grpc.ssl_target_name_override", config.tls_config.server_name)],
+            options=channel_options,
         )
     return conn

--- a/hatchet_sdk/worker.py
+++ b/hatchet_sdk/worker.py
@@ -332,7 +332,7 @@ class Worker:
                     del self.tasks[run_id]
 
         # grace period of 1 second
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         # check if thread is still running, if so, kill it
         if run_id in self.threads:

--- a/hatchet_sdk/worker.py
+++ b/hatchet_sdk/worker.py
@@ -451,16 +451,6 @@ class Worker:
             sys.exit(0)
 
     def start(self, retry_count=1):
-        actions = self.action_registry.items()
-
-        for action_name, action_func in actions:
-            logger.debug(f"Registered action: {action_name}")
-
-            # if action_func._is_coroutine:
-            #     raise Exception(
-            #         "Cannot register async actions with the synchronous worker, use async_start instead."
-            #     )
-
         try:
             loop = asyncio.get_running_loop()
             self.loop = loop


### PR DESCRIPTION
Adds improvements to network reliability including: 
- Rejected heartbeats will automatically trigger a new connection request. Heartbeat rejections are a signal that either the engine is down or there isn't a listener established from the worker. 
- Sets the following channel options to match the implementation of the Typescript SDK:

```
channel_options = [
        ("grpc.keepalive_time_ms", 10 * 1000),
        ("grpc.keepalive_timeout_ms", 60 * 1000),
        ("grpc.client_idle_timeout_ms", 60 * 1000),
        ("grpc.http2.max_pings_without_data", 5),
        ("grpc.keepalive_permit_without_calls", 1),
    ]
```

- Shifts heartbeat to the main thread with an async implementation, which is necessary to interrupt asyncio event flags (which aren't multithreaded)