### PR TITLE
fix: add back listener method to client

### DIFF
--- a/hatchet_sdk/__init__.py
+++ b/hatchet_sdk/__init__.py
@@ -121,7 +121,7 @@ from hatchet_sdk.clients.rest.models.workflow_version_definition import (
 )
 from hatchet_sdk.clients.rest.models.workflow_version_meta import WorkflowVersionMeta
 
-from .client import new_client, ClientImpl
+from .client import ClientImpl, new_client
 from .clients.admin import ScheduleTriggerWorkflowOptions, TriggerWorkflowOptions
 from .clients.events import PushEventOptions
 from .clients.run_event_listener import StepRunEventType, WorkflowRunEventType

--- a/hatchet_sdk/__init__.py
+++ b/hatchet_sdk/__init__.py
@@ -121,7 +121,7 @@ from hatchet_sdk.clients.rest.models.workflow_version_definition import (
 )
 from hatchet_sdk.clients.rest.models.workflow_version_meta import WorkflowVersionMeta
 
-from .client import new_client
+from .client import new_client, ClientImpl
 from .clients.admin import ScheduleTriggerWorkflowOptions, TriggerWorkflowOptions
 from .clients.events import PushEventOptions
 from .clients.run_event_listener import StepRunEventType, WorkflowRunEventType

--- a/hatchet_sdk/client.py
+++ b/hatchet_sdk/client.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import grpc
 
+from hatchet_sdk.clients.run_event_listener import RunEventListenerClient
 from hatchet_sdk.clients.workflow_listener import PooledWorkflowRunListener
 from hatchet_sdk.connection import new_conn
 
@@ -41,8 +42,8 @@ class ClientImpl(Client):
         self.event = event_client
         self.rest = rest_client
         self.config = config
+        self.listener = RunEventListenerClient(config)
         self.workflow_listener = workflow_listener
-
 
 def with_host_port(host: str, port: int):
     def with_host_port_impl(config: ClientConfig):
@@ -52,7 +53,7 @@ def with_host_port(host: str, port: int):
     return with_host_port_impl
 
 
-def new_client(defaults: ClientConfig = {}, *opts_functions):
+def new_client(defaults: ClientConfig = {}, *opts_functions) -> ClientImpl:
     config: ClientConfig = ConfigLoader(".").load_client_config(defaults)
 
     for opt_function in opts_functions:

--- a/hatchet_sdk/client.py
+++ b/hatchet_sdk/client.py
@@ -45,6 +45,7 @@ class ClientImpl(Client):
         self.listener = RunEventListenerClient(config)
         self.workflow_listener = workflow_listener
 
+
 def with_host_port(host: str, port: int):
     def with_host_port_impl(config: ClientConfig):
         config.host = host

--- a/hatchet_sdk/clients/run_event_listener.py
+++ b/hatchet_sdk/clients/run_event_listener.py
@@ -177,12 +177,12 @@ class RunEventListenerClient:
     def __init__(self, config: ClientConfig):
         self.token = config.token
         self.config = config
-        self.client : DispatcherStub = None
+        self.client: DispatcherStub = None
 
     def stream(self, workflow_run_id: str):
-        if not isinstance(workflow_run_id, str) and hasattr(workflow_run_id, '__str__'):
+        if not isinstance(workflow_run_id, str) and hasattr(workflow_run_id, "__str__"):
             workflow_run_id = str(workflow_run_id)
-            
+
         if not self.client:
             aio_conn = new_conn(self.config, True)
             self.client = DispatcherStub(aio_conn)

--- a/hatchet_sdk/clients/run_event_listener.py
+++ b/hatchet_sdk/clients/run_event_listener.py
@@ -177,10 +177,16 @@ class RunEventListenerClient:
     def __init__(self, config: ClientConfig):
         self.token = config.token
         self.config = config
-        aio_conn = new_conn(config, True)
-        self.client = DispatcherStub(aio_conn)
+        self.client : DispatcherStub = None
 
     def stream(self, workflow_run_id: str):
+        if not isinstance(workflow_run_id, str) and hasattr(workflow_run_id, '__str__'):
+            workflow_run_id = str(workflow_run_id)
+            
+        if not self.client:
+            aio_conn = new_conn(self.config, True)
+            self.client = DispatcherStub(aio_conn)
+
         return RunEventListener(workflow_run_id, self.client, self.token)
 
     async def on(self, workflow_run_id: str, handler: callable = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.25.3"
+version = "0.25.4"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Adds back the top-level listener method to the client for streaming, along with a type-safe fix on workflow_run_id for backwards compatibility. 