### PR TITLE
fix: remove max_pings_without_data python

### DIFF
--- a/hatchet_sdk/connection.py
+++ b/hatchet_sdk/connection.py
@@ -32,7 +32,7 @@ def new_conn(config, aio=False):
         ("grpc.keepalive_time_ms", 10 * 1000),
         ("grpc.keepalive_timeout_ms", 60 * 1000),
         ("grpc.client_idle_timeout_ms", 60 * 1000),
-        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.http2.max_pings_without_data", 0),
         ("grpc.keepalive_permit_without_calls", 1),
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.0"
+version = "0.26.1"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Based on my reading of https://github.com/grpc/grpc/blob/master/doc/keepalive.md:

> This channel argument controls the maximum number of pings that can be sent when there is no data/header frame to be sent. gRPC Core will not continue sending pings if we run over the limit. Setting it to 0 allows sending pings without such a restriction. (Note that this is an unfortunate setting that does not agree with [A8-client-side-keepalive.md](https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md). There should ideally be no such restriction on the keepalive ping and we plan to deprecate it in the future.)

It seems that we'll only send a maximum of 5 pings over the channel if there's no data, which isn't ideal in our case as we'd like to continue sending pings. 