### PR TITLE
fix: update requirements to indicate python version >= 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.1"
+version = "0.26.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 grpcio = "^1.60.0"
 python-dotenv = "^1.0.0"
 protobuf = "^4.25.2"


### PR DESCRIPTION
Lower versions of Python don't work with our typing, and we can't support them at the moment. 