### PR TITLE
fix: namespace propagation from spawn_workflow

### DIFF
--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -135,7 +135,9 @@ class AdminClientAioImpl(AdminClientBase):
             if not self.pooled_workflow_listener:
                 self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
 
-            workflow_name = f"{self.namespace}{workflow_name}"
+            # if workflow_name does not start with namespace, prepend it
+            if self.namespace != "" and not workflow_name.startswith(self.namespace):
+                workflow_name = f"{self.namespace}{workflow_name}"
 
             request = self._prepare_workflow_request(workflow_name, input, options)
             resp: TriggerWorkflowResponse = await self.aio_client.TriggerWorkflow(
@@ -276,7 +278,8 @@ class AdminClientImpl(AdminClientBase):
             if not self.pooled_workflow_listener:
                 self.pooled_workflow_listener = PooledWorkflowRunListener(self.config)
 
-            workflow_name = f"{self.namespace}{workflow_name}"
+            if self.namespace != "" and not workflow_name.startswith(self.namespace):
+                workflow_name = f"{self.namespace}{workflow_name}"
 
             request = self._prepare_workflow_request(workflow_name, input, options)
             resp: TriggerWorkflowResponse = self.client.TriggerWorkflow(

--- a/hatchet_sdk/context.py
+++ b/hatchet_sdk/context.py
@@ -64,6 +64,7 @@ class ContextAioImpl(BaseContext):
         self, workflow_name: str, input: dict = {}, key: str = None
     ) -> WorkflowRunRef:
         options = self._prepare_workflow_options(key)
+
         return await self.admin_client.aio.run_workflow(workflow_name, input, options)
 
 
@@ -170,8 +171,6 @@ class Context(BaseContext):
         return default
 
     def spawn_workflow(self, workflow_name: str, input: dict = {}, key: str = None):
-        workflow_name = f"{self.namespace}{workflow_name}"
-
         options = self._prepare_workflow_options(key)
 
         return self.admin_client.run_workflow(workflow_name, input, options)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.1"
+version = "0.26.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 grpcio = "^1.60.0"
 python-dotenv = "^1.0.0"
 protobuf = "^4.25.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.2"
+version = "0.26.3"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Some calls of `spawn_workflow` are double-prefixing the namespace which throws a "workflow not found" error