### PR TITLE
fix: wait for tasks on graceful termination

### DIFF
--- a/hatchet_sdk/clients/dispatcher.py
+++ b/hatchet_sdk/clients/dispatcher.py
@@ -396,13 +396,11 @@ class DispatcherClientImpl(DispatcherClient):
             metadata=get_metadata(self.token),
         )
 
-    def send_group_key_action_event(self, in_: GroupKeyActionEvent):
-        response: ActionEventResponse = self.client.SendGroupKeyActionEvent(
+    async def send_group_key_action_event(self, in_: GroupKeyActionEvent):
+        await self.aio_client.SendGroupKeyActionEvent(
             in_,
             metadata=get_metadata(self.token),
         )
-
-        return response
 
     def put_overrides_data(self, data: OverridesData):
         response: ActionEventResponse = self.client.PutOverridesData(

--- a/hatchet_sdk/worker.py
+++ b/hatchet_sdk/worker.py
@@ -202,6 +202,7 @@ class Worker:
         action_func = self.action_registry.get(action_name)
 
         if action_func:
+
             def callback(task: asyncio.Task):
                 errored = False
                 cancelled = task.cancelled()
@@ -448,7 +449,7 @@ class Worker:
 
         self.killing = True
 
-        logger.info(f'Exiting gracefully...')
+        logger.info(f"Exiting gracefully...")
 
         try:
             self.listener.unregister()
@@ -458,7 +459,7 @@ class Worker:
         try:
             logger.info("Waiting for tasks to finish...")
 
-            await self.wait_for_tasks()                
+            await self.wait_for_tasks()
         except Exception as e:
             logger.error(f"Could not wait for tasks: {e}")
 
@@ -504,8 +505,12 @@ class Worker:
 
         self.loop.create_task(self.async_start(retry_count))
 
-        self.loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(self.exit_gracefully()))
-        self.loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(self.exit_gracefully()))
+        self.loop.add_signal_handler(
+            signal.SIGINT, lambda: asyncio.create_task(self.exit_gracefully())
+        )
+        self.loop.add_signal_handler(
+            signal.SIGTERM, lambda: asyncio.create_task(self.exit_gracefully())
+        )
         self.loop.add_signal_handler(signal.SIGQUIT, lambda: self.exit_forcefully())
 
         if created_loop:

--- a/hatchet_sdk/worker.py
+++ b/hatchet_sdk/worker.py
@@ -67,9 +67,6 @@ class Worker:
         self.thread_pool = ThreadPoolExecutor(max_workers=max_runs)
         self.threads: Dict[str, Thread] = {}  # Store step run ids and threads
 
-        signal.signal(signal.SIGINT, self.exit_gracefully)
-        signal.signal(signal.SIGTERM, self.exit_gracefully)
-
         self.killing = False
         self.handle_kill = handle_kill
 
@@ -205,7 +202,6 @@ class Worker:
         action_func = self.action_registry.get(action_name)
 
         if action_func:
-
             def callback(task: asyncio.Task):
                 errored = False
                 cancelled = task.cancelled()
@@ -224,7 +220,9 @@ class Worker:
                     event.eventPayload = str(errorWithTraceback(f"{e}", e))
 
                     try:
-                        self.dispatcher_client.send_group_key_action_event(event)
+                        asyncio.create_task(
+                            self.dispatcher_client.send_group_key_action_event(event)
+                        )
                     except Exception as e:
                         logger.error(f"Could not send action event: {e}")
 
@@ -237,7 +235,9 @@ class Worker:
                         raise e
 
                     # Send the action event to the dispatcher
-                    self.dispatcher_client.send_group_key_action_event(event)
+                    asyncio.create_task(
+                        self.dispatcher_client.send_group_key_action_event(event)
+                    )
 
                 # Remove the future from the dictionary
                 if action.get_group_key_run_id in self.tasks:
@@ -289,8 +289,9 @@ class Worker:
             except Exception as e:
                 logger.error(f"Could not create action event: {e}")
 
-            # Send the action event to the dispatcher
-            self.dispatcher_client.send_group_key_action_event(event)
+            asyncio.create_task(
+                self.dispatcher_client.send_group_key_action_event(event)
+            )
 
             try:
                 await task
@@ -440,26 +441,56 @@ class Worker:
         for action_name, action_func in workflow.get_actions():
             self.action_registry[action_name] = create_action_function(action_func)
 
-    def exit_gracefully(self, signum, frame):
+    async def exit_gracefully(self):
+        if self.killing:
+            self.exit_forcefully()
+            return
+
         self.killing = True
 
-        logger.info("Gracefully exiting hatchet worker...")
+        logger.info(f'Exiting gracefully...')
 
         try:
             self.listener.unregister()
         except Exception as e:
             logger.error(f"Could not unregister worker: {e}")
 
-        # cancel all futures
-        # for future in self.tasks.values():
-        #     try:
-        #         future.result()
-        #     except Exception as e:
-        #         logger.error(f"Could not wait for future: {e}")
+        try:
+            logger.info("Waiting for tasks to finish...")
 
-        if self.handle_kill:
-            logger.info("Exiting...")
-            sys.exit(0)
+            await self.wait_for_tasks()                
+        except Exception as e:
+            logger.error(f"Could not wait for tasks: {e}")
+
+        # Wait for 1 second to allow last calls to flush. These are calls which have been
+        # added to the event loop as callbacks to tasks, so we're not aware of them in the
+        # task list.
+        await asyncio.sleep(1)
+
+        self.loop.stop()
+
+    def exit_forcefully(self):
+        self.killing = True
+
+        logger.info("Forcefully exiting hatchet worker...")
+
+        try:
+            self.listener.unregister()
+        except Exception as e:
+            logger.error(f"Could not unregister worker: {e}")
+
+        self.loop.stop()
+
+    async def wait_for_tasks(self):
+        # wait for all futures to finish
+        for taskId in list(self.tasks.keys()):
+            try:
+                logger.info(f"Waiting for task {taskId} to finish...")
+
+                if taskId in self.tasks:
+                    await self.tasks.get(taskId)
+            except Exception as e:
+                pass
 
     def start(self, retry_count=1):
         try:
@@ -473,8 +504,15 @@ class Worker:
 
         self.loop.create_task(self.async_start(retry_count))
 
+        self.loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(self.exit_gracefully()))
+        self.loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(self.exit_gracefully()))
+        self.loop.add_signal_handler(signal.SIGQUIT, lambda: self.exit_forcefully())
+
         if created_loop:
             self.loop.run_forever()
+
+            if self.handle_kill:
+                sys.exit(0)
 
     async def async_start(self, retry_count=1):
         logger.info("Starting worker...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.3"
+version = "0.26.4"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.1"
+version = "0.26.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 grpcio = "^1.60.0"
 python-dotenv = "^1.0.0"
 protobuf = "^4.25.2"


### PR DESCRIPTION
Adds support for awaiting all running tasks when a sigint/sigterm handler is received. 

Note that `Unregister` (internally calling `Unsubscribe`) is called as early as possible - there need to be some small changes to the Hatchet engine so that we track a shutdown state on the workers, so that new tasks stop being assigned but old tasks continue to be assigned to the worker. 