### PR TITLE
feat: add status method to `Worker` instances

### DIFF
--- a/hatchet_sdk/__init__.py
+++ b/hatchet_sdk/__init__.py
@@ -127,7 +127,7 @@ from .clients.events import PushEventOptions
 from .clients.run_event_listener import StepRunEventType, WorkflowRunEventType
 from .context import Context
 from .hatchet import ClientConfig, Hatchet
-from .worker import Worker
+from .worker import Worker, WorkerStatus
 from .workflows_pb2 import (
     ConcurrencyLimitStrategy,
     CreateWorkflowVersionOpts,

--- a/hatchet_sdk/clients/dispatcher.py
+++ b/hatchet_sdk/clients/dispatcher.py
@@ -149,11 +149,15 @@ class ActionListenerImpl(WorkerActionListener):
         self.worker_id = worker_id
         self.retries = 0
         self.last_connection_attempt = 0
+        self.last_heartbeat_succeeded = True  # start in a healthy state
         self.heartbeat_thread: threading.Thread = None
         self.run_heartbeat = True
         self.listen_strategy = "v2"
         self.stop_signal = False
         self.logger = logger.bind(worker_id=worker_id)
+
+    def is_healthy(self):
+        return self.last_heartbeat_succeeded
 
     def heartbeat(self):
         # send a heartbeat every 4 seconds
@@ -170,9 +174,13 @@ class ActionListenerImpl(WorkerActionListener):
                     timeout=5,
                     metadata=get_metadata(self.token),
                 )
+
+                self.last_heartbeat_succeeded = True
             except grpc.RpcError as e:
                 # we don't reraise the error here, as we don't want to stop the heartbeat thread
                 logger.error(f"Failed to send heartbeat: {e}")
+
+                self.last_heartbeat_succeeded = False
 
                 if self.interrupt is not None:
                     self.interrupt.set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.26.1"
+version = "0.26.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 grpcio = "^1.60.0"
 python-dotenv = "^1.0.0"
 protobuf = "^4.25.2"


### PR DESCRIPTION
Adds a status method so that clients can inspect their own worker status and make restart decisions. 