### PR TITLE
Allow circumvention of configuration from environment with a classmethod/parameter to init

### DIFF
--- a/hatchet_sdk/client.py
+++ b/hatchet_sdk/client.py
@@ -32,17 +32,15 @@ class Client:
 class ClientImpl(Client):
 
     @classmethod
-    def new_from_environment(
-        cls, defaults: ClientConfig = ClientConfig(), *opts_functions
-    ):
+    def from_environment(cls, defaults: ClientConfig = ClientConfig(), *opts_functions):
         config: ClientConfig = ConfigLoader(".").load_client_config(defaults)
         for opt_function in opts_functions:
             opt_function(config)
 
-        return cls.new_from_config(config)
+        return cls.from_config(config)
 
     @classmethod
-    def new_from_config(cls, config: ClientConfig = ClientConfig()):
+    def from_config(cls, config: ClientConfig = ClientConfig()):
         if config.tls_config is None:
             raise ValueError("TLS config is required")
 
@@ -94,5 +92,5 @@ def with_host_port(host: str, port: int):
     return with_host_port_impl
 
 
-new_client = ClientImpl.new_from_environment
-new_client_raw = ClientImpl.new_from_config
+new_client = ClientImpl.from_environment
+new_client_raw = ClientImpl.from_config

--- a/hatchet_sdk/client.py
+++ b/hatchet_sdk/client.py
@@ -32,7 +32,9 @@ class Client:
 class ClientImpl(Client):
 
     @classmethod
-    def new_from_environment(cls, defaults: ClientConfig = ClientConfig(), *opts_functions):
+    def new_from_environment(
+        cls, defaults: ClientConfig = ClientConfig(), *opts_functions
+    ):
         config: ClientConfig = ConfigLoader(".").load_client_config(defaults)
         for opt_function in opts_functions:
             opt_function(config)

--- a/hatchet_sdk/client.py
+++ b/hatchet_sdk/client.py
@@ -31,6 +31,41 @@ class Client:
 
 class ClientImpl(Client):
 
+    @classmethod
+    def new_from_environment(cls, defaults: ClientConfig = ClientConfig(), *opts_functions):
+        config: ClientConfig = ConfigLoader(".").load_client_config(defaults)
+        for opt_function in opts_functions:
+            opt_function(config)
+
+        return cls.new_from_config(config)
+
+    @classmethod
+    def new_from_config(cls, config: ClientConfig = ClientConfig(), *opts_functions):
+
+        if config.tls_config is None:
+            raise ValueError("TLS config is required")
+
+        if config.host_port is None:
+            raise ValueError("Host and port are required")
+
+        conn: grpc.Channel = new_conn(config)
+
+        # Instantiate client implementations
+        event_client = new_event(conn, config)
+        admin_client = new_admin(config)
+        dispatcher_client = new_dispatcher(config)
+        rest_client = RestApi(config.server_url, config.token, config.tenant_id)
+        workflow_listener_client = None
+
+        return cls(
+            event_client,
+            admin_client,
+            dispatcher_client,
+            workflow_listener_client,
+            rest_client,
+            config,
+        )
+
     def __init__(
         self,
         event_client: EventClientImpl,
@@ -58,32 +93,5 @@ def with_host_port(host: str, port: int):
     return with_host_port_impl
 
 
-def new_client(defaults: ClientConfig = ClientConfig(), *opts_functions) -> ClientImpl:
-    config: ClientConfig = ConfigLoader(".").load_client_config(defaults)
-
-    for opt_function in opts_functions:
-        opt_function(config)
-
-    if config.tls_config is None:
-        raise ValueError("TLS config is required")
-
-    if config.host_port is None:
-        raise ValueError("Host and port are required")
-
-    conn: grpc.Channel = new_conn(config)
-
-    # Instantiate client implementations
-    event_client = new_event(conn, config)
-    admin_client = new_admin(config)
-    dispatcher_client = new_dispatcher(config)
-    rest_client = RestApi(config.server_url, config.token, config.tenant_id)
-    workflow_listener_client = None
-
-    return ClientImpl(
-        event_client,
-        admin_client,
-        dispatcher_client,
-        workflow_listener_client,
-        rest_client,
-        config,
-    )
+new_client = ClientImpl.new_from_environment
+new_client_raw = ClientImpl.new_from_config

--- a/hatchet_sdk/client.py
+++ b/hatchet_sdk/client.py
@@ -40,8 +40,7 @@ class ClientImpl(Client):
         return cls.new_from_config(config)
 
     @classmethod
-    def new_from_config(cls, config: ClientConfig = ClientConfig(), *opts_functions):
-
+    def new_from_config(cls, config: ClientConfig = ClientConfig()):
         if config.tls_config is None:
             raise ValueError("TLS config is required")
 

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -25,7 +25,7 @@ class Hatchet:
 
     @classmethod
     def from_config(cls, config: ClientConfig, **kwargs):
-        return cls(client=new_client_raw(config), **kwawrgs)
+        return cls(client=new_client_raw(config), **kwargs)
 
     def __init__(
         self,

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -4,12 +4,12 @@ import random
 from functools import wraps
 from io import StringIO
 from logging import Logger, StreamHandler
-from typing import List
+from typing import List, Optional
 
 from hatchet_sdk.loader import ClientConfig
 from hatchet_sdk.rate_limit import RateLimit
 
-from .client import ClientImpl, new_client
+from .client import ClientImpl, new_client, new_client_raw
 from .logger import logger
 from .worker import Worker
 from .workflow import WorkflowMeta
@@ -19,13 +19,24 @@ from .workflows_pb2 import ConcurrencyLimitStrategy, CreateStepRateLimit
 class Hatchet:
     client: ClientImpl
 
+    @classmethod
+    def from_environment(cls, defaults: ClientConfig = ClientConfig(), **kwargs):
+        return cls(client=new_client(defaults), **kwargs)
+
+    @classmethod
+    def from_config(cls, config: ClientConfig, **kwargs):
+        return cls(client=new_client_raw(config), **kwawrgs)
+
     def __init__(
         self,
-        debug=False,
+        client: Optional[ClientImpl] = None,
         config: ClientConfig = ClientConfig(),
+        debug=False,
     ):
-        # initialize a client
-        self.client = new_client(config)
+        if client is not None:
+            self.client = client
+        else:
+            self.client = new_client(config)
 
         if not debug:
             logger.disable("hatchet_sdk")

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -120,9 +120,9 @@ class Hatchet:
 
     def __init__(
         self,
+        debug: bool = False,
         client: Optional[ClientImpl] = None,
         config: ClientConfig = ClientConfig(),
-        debug=False,
     ):
         if client is not None:
             self.client = client

--- a/hatchet_sdk/worker.py
+++ b/hatchet_sdk/worker.py
@@ -27,7 +27,7 @@ from hatchet_sdk.clients.run_event_listener import new_listener
 from hatchet_sdk.clients.workflow_listener import PooledWorkflowRunListener
 from hatchet_sdk.loader import ClientConfig
 
-from .client import new_client
+from .client import new_client, new_client_raw
 from .clients.dispatcher import (
     Action,
     ActionListenerImpl,
@@ -143,7 +143,7 @@ class Worker:
     ):
         # We store the config so we can dynamically create clients for the dispatcher client.
         self.config = config
-        self.client = new_client(config)
+        self.client = new_client_raw(config)
         self.name = self.client.config.namespace + name
         self.max_runs = max_runs
         self.tasks: Dict[str, asyncio.Task] = {}  # Store run ids and futures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.28.1"
+version = "0.28.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes #65

This is a sketch of how a minimally intrusive version of this could work.

The default behavior is left intact, but you can use `new_from_config` to avoid the configuration from the environment.