### PR TITLE
fix: handle steps with uppercase

### DIFF
--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -37,7 +37,7 @@ class Hatchet:
         limit_strategy: ConcurrencyLimitStrategy = ConcurrencyLimitStrategy.CANCEL_IN_PROGRESS,
     ):
         def inner(func):
-            func._concurrency_fn_name = name or func.__name__
+            func._concurrency_fn_name = name.lower() or str(func.__name__).lower()
             func._concurrency_max_runs = max_runs
             func._concurrency_limit_strategy = limit_strategy
 
@@ -84,7 +84,7 @@ class Hatchet:
                     for rate_limit in rate_limits or []
                 ]
 
-            func._step_name = name or func.__name__
+            func._step_name = name.lower() or str(func.__name__).lower()
             func._step_parents = parents
             func._step_timeout = timeout
             func._step_retries = retries
@@ -108,7 +108,7 @@ class Hatchet:
                     for rate_limit in rate_limits or []
                 ]
 
-            func._on_failure_step_name = name or func.__name__
+            func._on_failure_step_name = name.lower() or str(func.__name__).lower()
             func._on_failure_step_timeout = timeout
             func._on_failure_step_retries = retries
             func._on_failure_step_rate_limits = limits

--- a/hatchet_sdk/workflow.py
+++ b/hatchet_sdk/workflow.py
@@ -18,17 +18,17 @@ class WorkflowMeta(type):
         serviceName = namespace + name.lower()
 
         concurrencyActions: stepsType = [
-            (func_name, attrs.pop(func_name))
+            (getattr(func, "_concurrency_fn_name"), attrs.pop(func_name))
             for func_name, func in list(attrs.items())
             if hasattr(func, "_concurrency_fn_name")
         ]
         steps: stepsType = [
-            (func_name, attrs.pop(func_name))
+            (getattr(func, "_step_name"), attrs.pop(func_name))
             for func_name, func in list(attrs.items())
             if hasattr(func, "_step_name")
         ]
         onFailureSteps: stepsType = [
-            (func_name, attrs.pop(func_name))
+            (getattr(func, "_on_failure_step_name"), attrs.pop(func_name))
             for func_name, func in list(attrs.items())
             if hasattr(func, "_on_failure_step_name")
         ]
@@ -70,16 +70,15 @@ class WorkflowMeta(type):
 
         createStepOpts: List[CreateWorkflowStepOpts] = [
             CreateWorkflowStepOpts(
-                readable_id=func_name,
-                action=serviceName + ":" + func_name,
+                readable_id=step_name,
+                action=serviceName + ":" + step_name,
                 timeout=func._step_timeout or "60s",
                 inputs="{}",
                 parents=[x for x in func._step_parents],
                 retries=func._step_retries,
                 rate_limits=func._step_rate_limits,
             )
-            for func_name, func in attrs.items()
-            if hasattr(func, "_step_name")
+            for step_name, func in steps
         ]
 
         concurrency: WorkflowConcurrencyOpts | None = None


### PR DESCRIPTION
Handles steps which have an upper or lowercase. All actions are lowercased in the Hatchet engine, so we won't respect case sensitivity in the client. Step names can always be overwritten using `name=` to handle collisions.

Fixes #70 