### PR TITLE
feat: cancel via rest api

### DIFF
--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -1,5 +1,9 @@
 from typing import Any, Dict
 
+from hatchet_sdk.clients.rest.models.workflow_runs_cancel_request import (
+    WorkflowRunsCancelRequest,
+)
+
 from .rest.api.log_api import LogApi
 from .rest.api.step_run_api import StepRunApi
 from .rest.api.workflow_api import WorkflowApi
@@ -60,6 +64,14 @@ class RestApi:
         return self.workflow_api.workflow_run_get(
             tenant=self.tenant_id,
             workflow_run=workflow_run_id,
+        )
+
+    def workflow_run_cancel(self, workflow_run_id: str):
+        return self.workflow_run_api.workflow_run_cancel(
+            tenant=self.tenant_id,
+            workflow_runs_cancel_request=WorkflowRunsCancelRequest(
+                workflowRunIds=[workflow_run_id],
+            ),
         )
 
     def workflow_run_create(self, workflow_id: str, input: Dict[str, Any]):

--- a/hatchet_sdk/worker.py
+++ b/hatchet_sdk/worker.py
@@ -428,8 +428,7 @@ class Worker:
             # check if thread is still running, if so, print a warning
             if run_id in self.threads:
                 logger.warning(
-                    f"""Thread {self.threads[run_id].ident} with run id {run_id} is still running after cancellation. 
-                    This could cause the thread pool to get blocked and prevent new tasks from running."""
+                    f"Thread {self.threads[run_id].ident} with run id {run_id} is still running after cancellation. This could cause the thread pool to get blocked and prevent new tasks from running."
                 )
         finally:
             self.cleanup_run_id(run_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.27.2"
+version = "0.28.0"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Adds a method for cancellation that can be called via `hatchet.rest.workflow_run_cancel(workflowRun.workflow_run_id)`. 