### PR TITLE
fix: retry listener delay

### DIFF
--- a/hatchet_sdk/clients/workflow_listener.py
+++ b/hatchet_sdk/clients/workflow_listener.py
@@ -111,6 +111,7 @@ class PooledWorkflowRunListener:
 
                                 t.cancel()
                                 self.listener.cancel()
+                                await asyncio.sleep(DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL)
                                 break
 
                             workflow_event: WorkflowRunEvent = t.result()
@@ -125,10 +126,6 @@ class PooledWorkflowRunListener:
 
                     except grpc.RpcError as e:
                         logger.error(f"grpc error in workflow run listener: {e}")
-                        await asyncio.sleep(DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL)
-                        continue
-                    except Exception as e:
-                        logger.error(f"error in workflow run listener: {e}")
                         await asyncio.sleep(DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL)
                         continue
 

--- a/hatchet_sdk/clients/workflow_listener.py
+++ b/hatchet_sdk/clients/workflow_listener.py
@@ -111,7 +111,9 @@ class PooledWorkflowRunListener:
 
                                 t.cancel()
                                 self.listener.cancel()
-                                await asyncio.sleep(DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL)
+                                await asyncio.sleep(
+                                    DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL
+                                )
                                 break
 
                             workflow_event: WorkflowRunEvent = t.result()

--- a/hatchet_sdk/clients/workflow_listener.py
+++ b/hatchet_sdk/clients/workflow_listener.py
@@ -15,7 +15,7 @@ from ..loader import ClientConfig
 from ..logger import logger
 from ..metadata import get_metadata
 
-DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL = 1  # seconds
+DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL = 3  # seconds
 DEFAULT_WORKFLOW_LISTENER_RETRY_COUNT = 5
 DEFAULT_WORKFLOW_LISTENER_INTERRUPT_INTERVAL = 1800  # 30 minutes
 
@@ -125,7 +125,13 @@ class PooledWorkflowRunListener:
 
                     except grpc.RpcError as e:
                         logger.error(f"grpc error in workflow run listener: {e}")
+                        await asyncio.sleep(DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL)
                         continue
+                    except Exception as e:
+                        logger.error(f"error in workflow run listener: {e}")
+                        await asyncio.sleep(DEFAULT_WORKFLOW_LISTENER_RETRY_INTERVAL)
+                        continue
+
         except Exception as e:
             logger.error(f"Error in workflow run listener: {e}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.27.5"
+version = "0.27.6"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
If the workflow run listener gets interrupted we'll hit a loop that constantly attempts to retry