### PR TITLE
chore: remove loguru in favor of std logger

### DIFF
--- a/hatchet_sdk/clients/dispatcher.py
+++ b/hatchet_sdk/clients/dispatcher.py
@@ -138,7 +138,7 @@ class ActionListenerImpl(WorkerActionListener):
         self.run_heartbeat = True
         self.listen_strategy = "v2"
         self.stop_signal = False
-        self.logger = logger.bind(worker_id=worker_id)
+        self.logger = logger
 
     def is_healthy(self):
         return self.last_heartbeat_succeeded

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -27,8 +27,8 @@ class Hatchet:
         # initialize a client
         self.client = new_client(config)
 
-        if not debug:
-            logger.disable("hatchet_sdk")
+        if debug:
+            logger.setLevel(logging.DEBUG)
 
     def concurrency(
         self,

--- a/hatchet_sdk/logger.py
+++ b/hatchet_sdk/logger.py
@@ -1,13 +1,13 @@
-import os
 import sys
+import logging
 
-from loguru import logger
+# logging config
+logging.basicConfig(
+    level=logging.ERROR,
+    format='[%(levelname)s] hatchet -- %(asctime)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout)
+    ]
+)
 
-# loguru config
-config = {
-    "handlers": [
-        {"sink": sys.stdout, "format": "[{level}] hatchet -- {time} - {message}"},
-    ],
-}
-
-logger.configure(**config)
+logger = logging.getLogger()

--- a/hatchet_sdk/logger.py
+++ b/hatchet_sdk/logger.py
@@ -1,13 +1,11 @@
-import sys
 import logging
+import sys
 
 # logging config
 logging.basicConfig(
     level=logging.ERROR,
-    format='[%(levelname)s] hatchet -- %(asctime)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+    format="[%(levelname)s] hatchet -- %(asctime)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
 
 logger = logging.getLogger()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.29.0"
+version = "0.29.1"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Loguru having a single configuration/logger object was causing issues when called by users. This replaces our debug logger with a std logger.