### PR TITLE
feat: return event after push

### DIFF
--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -6,7 +6,7 @@ from typing import Dict, TypedDict
 import grpc
 from google.protobuf import timestamp_pb2
 
-from ..events_pb2 import PushEventRequest, PutLogRequest, PutStreamEventRequest
+from ..events_pb2 import PushEventRequest, PutLogRequest, PutStreamEventRequest, Event
 from ..events_pb2_grpc import EventsServiceStub
 from ..loader import ClientConfig
 from ..metadata import get_metadata
@@ -37,7 +37,7 @@ class EventClientImpl:
         self.token = config.token
         self.namespace = config.namespace
 
-    def push(self, event_key, payload, options: PushEventOptions = None):
+    def push(self, event_key, payload, options: PushEventOptions = None) -> Event:
 
         namespaced_event_key = self.namespace + event_key
 
@@ -60,7 +60,7 @@ class EventClientImpl:
         )
 
         try:
-            self.client.Push(request, metadata=get_metadata(self.token))
+            return self.client.Push(request, metadata=get_metadata(self.token))
         except grpc.RpcError as e:
             raise ValueError(f"gRPC error: {e}")
 

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -6,7 +6,7 @@ from typing import Dict, TypedDict
 import grpc
 from google.protobuf import timestamp_pb2
 
-from ..events_pb2 import PushEventRequest, PutLogRequest, PutStreamEventRequest, Event
+from ..events_pb2 import Event, PushEventRequest, PutLogRequest, PutStreamEventRequest
 from ..events_pb2_grpc import EventsServiceStub
 from ..loader import ClientConfig
 from ..metadata import get_metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.29.1"
+version = "0.30.0"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Example usage:

```py
event = client.event.push("user:create", {"test": "test"})

print(event.eventId)
```