### PR TITLE
fix: remove listener ref when cleaning up subscriptions

### DIFF
--- a/hatchet_sdk/clients/workflow_listener.py
+++ b/hatchet_sdk/clients/workflow_listener.py
@@ -176,8 +176,11 @@ class PooledWorkflowRunListener:
         del self.events[subscription_id]
 
         if len(self.events) == 0:
+            self.listener = None
+
             if self.interrupter is not None and not self.interrupter.done():
                 self.interrupter.cancel()
+
             self.interrupter = None
 
             if not init_producer.done():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.31.1"
+version = "0.31.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
In the workflow run listener, not cleaning up `self.listener` was causing an issue where `.result()` on a child workflow called a second time would hang forever.