### PR TITLE
fix: don't propagate hatchet logs to root

### DIFF
--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -1,9 +1,4 @@
-import asyncio
 import logging
-import random
-from functools import wraps
-from io import StringIO
-from logging import Logger, StreamHandler
 from typing import List, Optional
 
 from hatchet_sdk.loader import ClientConfig

--- a/hatchet_sdk/logger.py
+++ b/hatchet_sdk/logger.py
@@ -1,11 +1,13 @@
 import logging
 import sys
 
-# logging config
-logging.basicConfig(
-    level=logging.ERROR,
-    format="[%(levelname)s] hatchet -- %(asctime)s - %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
-)
-
+# Create a named logger
 logger = logging.getLogger("hatchet")
+logger.setLevel(logging.ERROR)
+
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter("[%(levelname)s] hatchet -- %(asctime)s - %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+logger.propagate = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.31.3"
+version = "0.31.4"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Don't propagate hatchet logs to a root logger instance, which will lead to duplicated logging. 