### PR TITLE
Add Sync-Compatible Result Function

### DIFF
--- a/hatchet_sdk/workflow_run.py
+++ b/hatchet_sdk/workflow_run.py
@@ -1,10 +1,66 @@
-from typing import Any, Coroutine, Generic, TypeVar
+import asyncio
+from threading import Thread
+from typing import Generic, TypeVar
 
 from hatchet_sdk.clients.run_event_listener import (
     RunEventListener,
     RunEventListenerClient,
 )
 from hatchet_sdk.clients.workflow_listener import PooledWorkflowRunListener
+
+
+class EventLoopThread:
+    """A class that manages an asyncio event loop running in a separate thread."""
+
+    def __init__(self):
+        """
+        Initializes the EventLoopThread by creating or getting an event loop
+        and setting up a thread to run the loop.
+        """
+        self.loop: asyncio.AbstractEventLoop = self.get_or_create_event_loop()
+        self.thread: Thread = Thread(target=self.run_loop_in_thread, args=(self.loop,))
+
+    def __enter__(self) -> asyncio.AbstractEventLoop:
+        """
+        Starts the thread running the event loop when entering the context.
+
+        Returns:
+            asyncio.AbstractEventLoop: The event loop running in the separate thread.
+        """
+        self.thread.start()
+        return self.loop
+
+    def __exit__(self) -> None:
+        """
+        Stops the event loop and joins the thread when exiting the context.
+        """
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join()
+
+    def run_loop_in_thread(self, loop: asyncio.AbstractEventLoop) -> None:
+        """
+        Sets the event loop for the current thread and runs it forever.
+
+        Args:
+            loop (asyncio.AbstractEventLoop): The event loop to run.
+        """
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    def get_or_create_event_loop(self) -> asyncio.AbstractEventLoop:
+        """
+        Gets the current event loop or creates a new one if none exists.
+
+        Returns:
+            asyncio.AbstractEventLoop: The current or newly created event loop.
+        """
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError as e:
+            if str(e).startswith("There is no current event loop in thread"):
+                return asyncio.new_event_loop()
+            else:
+                raise e
 
 
 class WorkflowRunRef:
@@ -29,6 +85,12 @@ class WorkflowRunRef:
     def result(self):
         return self.workflow_listener.result(self.workflow_run_id)
 
+    def sync_result(self):
+        with EventLoopThread() as loop:
+            coro = self.workflow_listener.result(self.workflow_run_id)
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+            return future.result()
+
 
 T = TypeVar("T")
 
@@ -37,7 +99,6 @@ class RunRef(WorkflowRunRef, Generic[T]):
     async def result(self) -> T:
         res = await self.workflow_listener.result(self.workflow_run_id)
 
-        # if the dict only has 1 key, return the value of that key
         if len(res) == 1:
             return list(res.values())[0]
 

--- a/hatchet_sdk/workflow_run.py
+++ b/hatchet_sdk/workflow_run.py
@@ -1,6 +1,6 @@
 import asyncio
 from threading import Thread
-from typing import Generic, TypeVar
+from typing import Coroutine, Generic, TypeVar
 
 from hatchet_sdk.clients.run_event_listener import (
     RunEventListener,
@@ -77,7 +77,10 @@ class WorkflowRunRef:
     def stream(self) -> RunEventListener:
         return self.workflow_run_event_listener.stream(self.workflow_run_id)
 
-    def result(self):
+    def result(self) -> Coroutine:
+        return self.workflow_listener.result(self.workflow_run_id)
+
+    def sync_result(self) -> dict:
         loop = get_or_create_event_loop()
         if loop is None:
             with EventLoopThread() as loop:


### PR DESCRIPTION
Runs the Async Coroutines in a threadsafe loop. Allows `ref.result()` calls to be made in a non AsyncIO context when calling `ref.sync_result()`