### PR TITLE
bug: workflow_run_list belongs to WorkflowApi not WorkflowRunApi

### DIFF
--- a/examples/affinity-workers/worker.py
+++ b/examples/affinity-workers/worker.py
@@ -27,6 +27,7 @@ class AffinityWorkflow:
 
         return {"worker": context.worker.id()}
 
+
 def main():
     worker = hatchet.worker(
         "affinity-worker",
@@ -38,6 +39,7 @@ def main():
     )
     worker.register_workflow(AffinityWorkflow())
     worker.start()
+
 
 if __name__ == "__main__":
     main()

--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -133,7 +133,7 @@ class AsyncRestApi:
         order_by_field: WorkflowRunOrderByField | None = None,
         order_by_direction: WorkflowRunOrderByDirection | None = None,
     ) -> WorkflowRunList:
-        return await self.workflow_run_api.workflow_run_list(
+        return await self.workflow_api.workflow_run_list(
             tenant=self.tenant_id,
             offset=offset,
             limit=limit,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.36.3"
+version = "0.36.4"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
```
File ~/Library/Caches/pypoetry/virtualenvs/railbird-pQIr3DSd-py3.11/lib/python3.11/site-packages/hatchet_sdk/clients/rest_client.py:136, in AsyncRestApi.workflow_run_list(self, workflow_id, offset, limit, event_id, parent_workflow_run_id, parent_step_run_id, statuses, kinds, additional_metadata, order_by_field, order_by_direction)
    122 async def workflow_run_list(
    123     self,
    124     workflow_id: str | None = None,
   (...)
    134     order_by_direction: WorkflowRunOrderByDirection | None = None,
    135 ) -> WorkflowRunList:
--> 136     return await self.workflow_run_api.workflow_run_list(
    137         tenant=self.tenant_id,
    138         offset=offset,
    139         limit=limit,
    140         workflow_id=workflow_id,
    141         event_id=event_id,
    142         parent_workflow_run_id=parent_workflow_run_id,
    143         parent_step_run_id=parent_step_run_id,
    144         statuses=statuses,
    145         kinds=kinds,
    146         additional_metadata=additional_metadata,
    147         order_by_field=order_by_field,
    148         order_by_direction=order_by_direction,
    149     )

AttributeError: 'WorkflowRunApi' object has no attribute 'workflow_run_list'
```

this method belongs to workflow_api. just fixing that.