### PR TITLE
Python Example Delimeters

### DIFF
--- a/examples/affinity-workers/worker.py
+++ b/examples/affinity-workers/worker.py
@@ -1,3 +1,4 @@
+#Python
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context, Hatchet, WorkerLabelComparator
@@ -6,7 +7,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START specifying-step-desired-labels
 @hatchet.workflow(on_events=["affinity:run"])
 class AffinityWorkflow:
     @hatchet.step(
@@ -26,9 +27,11 @@ class AffinityWorkflow:
             context.worker.upsert_labels({"model": "fancy-ai-model-v2"})
 
         return {"worker": context.worker.id()}
+#END specifying-step-desired-labels
 
 
 def main():
+    #START specifying-worker-labels
     worker = hatchet.worker(
         "affinity-worker",
         max_runs=10,
@@ -37,6 +40,7 @@ def main():
             "memory": 512,
         },
     )
+    #END specifying-worker-labels
     worker.register_workflow(AffinityWorkflow())
     worker.start()
 

--- a/examples/cancellation/worker.py
+++ b/examples/cancellation/worker.py
@@ -1,3 +1,4 @@
+#Python
 import asyncio
 
 from dotenv import load_dotenv
@@ -8,7 +9,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START cancellation-mechanisms
 @hatchet.workflow(on_events=["user:create"])
 class CancelWorkflow:
     @hatchet.step(timeout="10s", retries=1)
@@ -21,7 +22,7 @@ class CancelWorkflow:
 
         if context.exit_flag:
             print("Cancelled")
-
+#END cancellation-mechanisms
 
 workflow = CancelWorkflow()
 worker = hatchet.worker("cancellation-worker", max_runs=4)

--- a/examples/concurrency_limit/worker.py
+++ b/examples/concurrency_limit/worker.py
@@ -10,7 +10,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START concurrency_cancel_in_progress
 @hatchet.workflow(on_events=["concurrency-test"])
 class ConcurrencyDemoWorkflow:
 
@@ -24,7 +24,7 @@ class ConcurrencyDemoWorkflow:
         time.sleep(3)
         print("executed step1")
         return {"run": input["run"]}
-
+#END concurrency_cancel_in_progress
 
 def main():
     workflow = ConcurrencyDemoWorkflow()

--- a/examples/concurrency_limit/worker.py
+++ b/examples/concurrency_limit/worker.py
@@ -1,3 +1,4 @@
+#Python
 import time
 
 from dotenv import load_dotenv
@@ -27,7 +28,9 @@ class ConcurrencyDemoWorkflow:
 
 def main():
     workflow = ConcurrencyDemoWorkflow()
+    #START setting-concurrency-on-workers
     worker = hatchet.worker("concurrency-demo-worker", max_runs=10)
+    #END setting-concurrency-on-workers
     worker.register_workflow(workflow)
 
     worker.start()

--- a/examples/concurrency_limit_rr/worker.py
+++ b/examples/concurrency_limit_rr/worker.py
@@ -1,3 +1,4 @@
+#Python
 import time
 
 from dotenv import load_dotenv
@@ -8,7 +9,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START concurrency_group_red_robin
 @hatchet.workflow(on_events=["concurrency-test"], schedule_timeout="10m")
 class ConcurrencyDemoWorkflowRR:
     @hatchet.concurrency(
@@ -25,7 +26,7 @@ class ConcurrencyDemoWorkflowRR:
         time.sleep(2)
         print("finished step1")
         pass
-
+#END concurrency_group_red_robin
 
 workflow = ConcurrencyDemoWorkflowRR()
 worker = hatchet.worker("concurrency-demo-worker-rr", max_runs=10)

--- a/examples/fanout/stream.py
+++ b/examples/fanout/stream.py
@@ -1,3 +1,4 @@
+#Python
 import asyncio
 import base64
 import json
@@ -10,7 +11,7 @@ from hatchet_sdk import new_client
 from hatchet_sdk.clients.admin import TriggerWorkflowOptions
 from hatchet_sdk.clients.run_event_listener import StepRunEventType
 
-
+#START streaming-by-additional-metadata
 async def main():
     load_dotenv()
     hatchet = new_client()
@@ -38,7 +39,7 @@ async def main():
 
     async for event in listener:
         print(event.type, event.payload)
-
+#END streaming-by-additional-metadata
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/manual_trigger/stream.py
+++ b/examples/manual_trigger/stream.py
@@ -1,3 +1,4 @@
+#Python
 import asyncio
 import base64
 import json
@@ -9,7 +10,7 @@ from hatchet_sdk import new_client
 from hatchet_sdk.clients.admin import TriggerWorkflowOptions
 from hatchet_sdk.clients.run_event_listener import StepRunEventType
 
-
+#START listeners
 async def main():
     load_dotenv()
     hatchet = new_client()
@@ -49,7 +50,7 @@ async def main():
     result = await workflowRun.result()
 
     print("result: " + json.dumps(result, indent=2))
-
+#END listeners
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/on_failure/worker.py
+++ b/examples/on_failure/worker.py
@@ -1,3 +1,4 @@
+#Python
 import json
 
 from dotenv import load_dotenv
@@ -8,7 +9,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START defining-an-on-failure-step
 @hatchet.workflow(on_events=["user:create"])
 class OnFailureWorkflow:
     @hatchet.step(timeout="1s")
@@ -23,7 +24,7 @@ class OnFailureWorkflow:
         if len(failures) == 1 and "step1 failed" in failures[0]["error"]:
             return {"status": "success"}
         raise Exception("unexpected failure")
-
+#END defining-an-on-failure-step
 
 def main():
     workflow = OnFailureWorkflow()

--- a/examples/rate_limit/worker.py
+++ b/examples/rate_limit/worker.py
@@ -1,3 +1,4 @@
+#Python
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context, Hatchet
@@ -7,19 +8,19 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START consuming-rate-limits
 @hatchet.workflow(on_events=["rate_limit:create"])
 class RateLimitWorkflow:
-
     @hatchet.step(rate_limits=[RateLimit(key="test-limit", units=1)])
     def step1(self, context: Context):
         print("executed step1")
         pass
-
+#END consuming-rate-limits
 
 def main():
+    #START declaring-global-limits
     hatchet.admin.put_rate_limit("test-limit", 2, RateLimitDuration.SECOND)
-
+    #END declaring-global-limits
     worker = hatchet.worker("rate-limit-worker", max_runs=10)
     worker.register_workflow(RateLimitWorkflow())
 

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -9,7 +9,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START how-to-use-step-level-retries
 @hatchet.workflow(on_events=["user:create"])
 class MyWorkflow:
     @hatchet.step(timeout="11s", retries=3)
@@ -20,7 +20,7 @@ class MyWorkflow:
         return {
             "step1": "step1",
         }
-
+#END how-to-use-step-level-retries
 
 def main():
     #START registering_workflows_starting_workers

--- a/examples/simple/worker.py
+++ b/examples/simple/worker.py
@@ -1,3 +1,4 @@
+#Python
 import time
 
 from dotenv import load_dotenv
@@ -22,11 +23,12 @@ class MyWorkflow:
 
 
 def main():
+    #START registering_workflows_starting_workers
     workflow = MyWorkflow()
     worker = hatchet.worker("test-worker", max_runs=1)
     worker.register_workflow(workflow)
     worker.start()
-
+    #END registering_workflows_starting_workers
 
 if __name__ == "__main__":
     main()

--- a/examples/sticky-workers/worker.py
+++ b/examples/sticky-workers/worker.py
@@ -1,3 +1,4 @@
+#Python
 from dotenv import load_dotenv
 
 from hatchet_sdk import Context, Hatchet, StickyStrategy
@@ -6,7 +7,7 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START setting-sticky-assignment
 @hatchet.workflow(on_events=["sticky:parent"], sticky=StickyStrategy.SOFT)
 class StickyWorkflow:
     @hatchet.step()
@@ -27,14 +28,15 @@ class StickyWorkflow:
         await ref.result()
 
         return {"worker": context.worker.id()}
+#END setting-sticky-assignment
 
-
+#START #sticky-child-workflows
 @hatchet.workflow(on_events=["sticky:child"], sticky=StickyStrategy.SOFT)
 class StickyChildWorkflow:
     @hatchet.step()
     def child(self, context: Context):
         return {"worker": context.worker.id()}
-
+#END sticky-child-workflows
 
 worker = hatchet.worker("sticky-worker", max_runs=10)
 worker.register_workflow(StickyWorkflow())

--- a/examples/timeout/worker.py
+++ b/examples/timeout/worker.py
@@ -1,3 +1,4 @@
+#Python
 import time
 
 from dotenv import load_dotenv
@@ -8,16 +9,17 @@ load_dotenv()
 
 hatchet = Hatchet(debug=True)
 
-
+#START scheduling-timeouts
 @hatchet.workflow(on_events=["timeout:create"])
 class TimeoutWorkflow:
-
+#END scheduling-timeouts
+#START step-timeouts
     @hatchet.step(timeout="4s")
     def step1(self, context: Context):
         time.sleep(5)
         return {"status": "success"}
-
-
+#END step-timeouts
+#START refreshing-timeouts
 @hatchet.workflow(on_events=["refresh:create"])
 class RefreshTimeoutWorkflow:
 
@@ -28,7 +30,7 @@ class RefreshTimeoutWorkflow:
         time.sleep(5)
 
         return {"status": "success"}
-
+#END refreshing-timeouts
 
 def main():
     worker = hatchet.worker("timeout-worker", max_runs=4)


### PR DESCRIPTION
Adding delimiters to the Python examples. We used our best judgement to set these delimeters. In some cases, these code blocks are not 1:1 to the examples in the docs (and in others, they can not be found at all in the examples folder).

Delimeters include:
- `#Python` at the front of the file.
- `#START (codeblock name)` at the start of the code block.
- `#END (codeblock name)` at the end of the code block.

Codeblock names should be unique within a language.