### PR TITLE
Expose Client Config in SDK Main Class

### DIFF
--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -205,6 +205,10 @@ class Hatchet:
     def config(self):
         return self._client.config
 
+    @property
+    def tenant_id(self):
+        return self._client.config.tenant_id
+
     concurrency = staticmethod(concurrency)
 
     workflow = staticmethod(workflow)

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -201,6 +201,10 @@ class Hatchet:
     def listener(self):
         return self._client.listener
 
+    @property
+    def config(self):
+        return self._client.config
+
     concurrency = staticmethod(concurrency)
 
     workflow = staticmethod(workflow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.36.9"
+version = "0.36.10"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Should let people easily access `tenant_id` as an example.