### PR TITLE
feat: support async event push on the event client

### DIFF
--- a/examples/events/test_event.py
+++ b/examples/events/test_event.py
@@ -12,3 +12,9 @@ async def test_event_push(hatchet: Hatchet):
     e = hatchet.event.push("user:create", {"test": "test"})
 
     assert e.eventId is not None
+
+@pytest.mark.asyncio(scope="session")
+async def test_async_event_push(hatchet: Hatchet):
+    e = await hatchet.event.async_push("user:create", {"test": "test"})
+
+    assert e.eventId is not None

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -1,6 +1,7 @@
+import asyncio
 import datetime
 import json
-from typing import Dict, TypedDict
+from typing import Dict, Optional, TypedDict
 
 import grpc
 from google.protobuf import timestamp_pb2
@@ -43,6 +44,13 @@ class EventClient:
         self.client = client
         self.token = config.token
         self.namespace = config.namespace
+
+    async def async_push(
+        self, event_key, payload, options: Optional[PushEventOptions] = None
+    ) -> Event:
+        return await asyncio.to_thread(
+            self.push, event_key=event_key, payload=payload, options=options
+        )
 
     @tenacity_retry
     def push(self, event_key, payload, options: PushEventOptions = None) -> Event:


### PR DESCRIPTION
This change adds support for pushing events asynchronously on the event client, accessible from `hatchet.event`. It is a simple wrapper to the synchronous version.