### PR TITLE
fix: send failure events when we cannot send a succeeded or failed event

### DIFF
--- a/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -8,6 +8,8 @@ from hatchet_sdk.clients.dispatcher.action_listener import (
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
 from hatchet_sdk.connection import new_conn
 from hatchet_sdk.contracts.dispatcher_pb2 import (
+    STEP_EVENT_TYPE_COMPLETED,
+    STEP_EVENT_TYPE_FAILED,
     ActionEventResponse,
     GroupKeyActionEvent,
     GroupKeyActionEventType,
@@ -20,8 +22,6 @@ from hatchet_sdk.contracts.dispatcher_pb2 import (
     WorkerLabels,
     WorkerRegisterRequest,
     WorkerRegisterResponse,
-    STEP_EVENT_TYPE_COMPLETED,
-    STEP_EVENT_TYPE_FAILED,
 )
 from hatchet_sdk.contracts.dispatcher_pb2_grpc import DispatcherStub
 
@@ -65,7 +65,6 @@ class DispatcherClient:
 
         return ActionListener(self.config, response.workerId)
 
-    
     async def send_step_action_event(
         self, action: Action, event_type: StepActionEventType, payload: str
     ):
@@ -73,13 +72,18 @@ class DispatcherClient:
             return await self._try_send_step_action_event(action, event_type, payload)
         except Exception as e:
             # for step action events, send a failure event when we cannot send the completed event
-            if event_type == STEP_EVENT_TYPE_COMPLETED or event_type == STEP_EVENT_TYPE_FAILED:
+            if (
+                event_type == STEP_EVENT_TYPE_COMPLETED
+                or event_type == STEP_EVENT_TYPE_FAILED
+            ):
                 await self._try_send_step_action_event(
-                    action, STEP_EVENT_TYPE_FAILED, "Failed to send finished event: " + str(e)
+                    action,
+                    STEP_EVENT_TYPE_FAILED,
+                    "Failed to send finished event: " + str(e),
                 )
 
             return
-        
+
     @tenacity_retry
     async def _try_send_step_action_event(
         self, action: Action, event_type: StepActionEventType, payload: str

--- a/hatchet_sdk/worker/action_listener_process.py
+++ b/hatchet_sdk/worker/action_listener_process.py
@@ -140,6 +140,8 @@ class WorkerActionListenerProcess:
     async def send_event(self, event: ActionEvent, retry_attempt: int = 1):
         try:
             match event.action.action_type:
+                # FIXME: all events sent from an execution of a function are of type ActionType.START_STEP_RUN since
+                # the action is re-used. We should change this. 
                 case ActionType.START_STEP_RUN:
                     # TODO right now we're sending two start_step_run events
                     # one on the action loop and one on the event loop

--- a/hatchet_sdk/worker/action_listener_process.py
+++ b/hatchet_sdk/worker/action_listener_process.py
@@ -141,7 +141,7 @@ class WorkerActionListenerProcess:
         try:
             match event.action.action_type:
                 # FIXME: all events sent from an execution of a function are of type ActionType.START_STEP_RUN since
-                # the action is re-used. We should change this. 
+                # the action is re-used. We should change this.
                 case ActionType.START_STEP_RUN:
                     # TODO right now we're sending two start_step_run events
                     # one on the action loop and one on the event loop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.37.1"
+version = "0.37.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Handles a case where sending a succeeded event payload fails due to serialization errors, payload too large, etc. This will now send a proper stack trace to Hatchet to track these failures.