### PR TITLE
MyPy Fixes for `Worker`, `Workflow` metaclass, `Context`, and some others

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Install linting tools
-        run: poetry install --no-root --only lint
+        run: poetry install --no-root
 
       - name: Run Black
         run: poetry run black . --check --verbose --diff --color

--- a/examples/pydantic/test_pydantic.py
+++ b/examples/pydantic/test_pydantic.py
@@ -1,0 +1,30 @@
+import pytest
+
+from hatchet_sdk import Hatchet
+
+
+# requires scope module or higher for shared event loop
+@pytest.mark.asyncio(scope="session")
+@pytest.mark.parametrize("worker", ["pydantic"], indirect=True)
+async def test_run_validation_error(hatchet: Hatchet, worker):
+    run = hatchet.admin.run_workflow(
+        "Parent",
+        {},
+    )
+
+    with pytest.raises(Exception, match="1 validation error for ParentInput"):
+        await run.result()
+
+
+# requires scope module or higher for shared event loop
+@pytest.mark.asyncio(scope="session")
+@pytest.mark.parametrize("worker", ["pydantic"], indirect=True)
+async def test_run(hatchet: Hatchet, worker):
+    run = hatchet.admin.run_workflow(
+        "Parent",
+        {"x": "foobar"},
+    )
+
+    result = await run.result()
+
+    assert len(result["spawn"]) == 3

--- a/examples/pydantic/trigger.py
+++ b/examples/pydantic/trigger.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from dotenv import load_dotenv
+
+from hatchet_sdk import new_client
+
+
+async def main():
+    load_dotenv()
+    hatchet = new_client()
+
+    hatchet.admin.run_workflow(
+        "Parent",
+        {"x": "foo bar baz"},
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/pydantic/worker.py
+++ b/examples/pydantic/worker.py
@@ -10,24 +10,21 @@ load_dotenv()
 hatchet = Hatchet(debug=True)
 
 
+# ❓ Pydantic
+# This workflow shows example usage of Pydantic within Hatchet
 class ParentInput(BaseModel):
     x: str
-
-
-def pretty_print(tag: str, model: BaseModel) -> None:
-    print()
-    print(tag, model, "\nType:", type(model))  ## This is an instance of `ChildInput`
-    print()
 
 
 @hatchet.workflow(input_validator=ParentInput)
 class Parent:
     @hatchet.step(timeout="5m")
     async def spawn(self, context: Context):
-        ## Cast your `workflow_input` to the type of your `input_validator`
-        input = cast(ParentInput, context.workflow_input())
+        # 👀 this step will always raise an exception
 
-        pretty_print("Workflow Input:", input)  ## This is a `ParentInput`
+        ## Use `typing.cast` to cast your `workflow_input`
+        ## to the type of your `input_validator`
+        input = cast(ParentInput, context.workflow_input())  ## This is a `ParentInput`
 
         child = await context.aio.spawn_workflow(
             "Child",
@@ -50,27 +47,30 @@ class StepResponse(BaseModel):
 class Child:
     @hatchet.step()
     def process(self, context: Context) -> StepResponse:
+        ## This is an instance `ChildInput`
         input = cast(ChildInput, context.workflow_input())
-
-        pretty_print("Workflow Input:", input)  ## This is a `ChildInput`
 
         return StepResponse(status="success")
 
     @hatchet.step(parents=["process"])
     def process2(self, context: Context) -> StepResponse:
+        ## This is an instance of `StepResponse`
         process_output = cast(StepResponse, context.step_output("process"))
-
-        pretty_print("Process Output:", process_output)  ## This is a `StepResponse`
 
         return {"status": "step 2 - success"}
 
     @hatchet.step(parents=["process2"])
     def process3(self, context: Context) -> StepResponse:
+        ## This is an instance of `StepResponse`, even though the
+        ## response of `process2` was a dictionary. Note that
+        ## Hatchet will attempt to parse that dictionary into
+        ## an object of type `StepResponse`
         process_2_output = cast(StepResponse, context.step_output("process2"))
 
-        pretty_print("Process 2 Output:", process_2_output)  ## This is a `StepResponse`
-
         return StepResponse(status="step 3 - success")
+
+
+# ‼️
 
 
 def main():

--- a/examples/pydantic/worker.py
+++ b/examples/pydantic/worker.py
@@ -20,8 +20,6 @@ class ParentInput(BaseModel):
 class Parent:
     @hatchet.step(timeout="5m")
     async def spawn(self, context: Context):
-        # 👀 this step will always raise an exception
-
         ## Use `typing.cast` to cast your `workflow_input`
         ## to the type of your `input_validator`
         input = cast(ParentInput, context.workflow_input())  ## This is a `ParentInput`

--- a/examples/pydantic/worker.py
+++ b/examples/pydantic/worker.py
@@ -1,0 +1,84 @@
+from typing import cast
+
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+from hatchet_sdk import Context, Hatchet
+
+load_dotenv()
+
+hatchet = Hatchet(debug=True)
+
+
+class ParentInput(BaseModel):
+    x: str
+
+
+def pretty_print(tag: str, model: BaseModel) -> None:
+    print()
+    print(tag, model, "\nType:", type(model))  ## This is an instance of `ChildInput`
+    print()
+
+
+@hatchet.workflow(input_validator=ParentInput)
+class Parent:
+    @hatchet.step(timeout="5m")
+    async def spawn(self, context: Context):
+        ## Cast your `workflow_input` to the type of your `input_validator`
+        input = cast(ParentInput, context.workflow_input())
+
+        pretty_print("Workflow Input:", input)  ## This is a `ParentInput`
+
+        child = await context.aio.spawn_workflow(
+            "Child",
+            {"a": 1, "b": "10"},
+        )
+
+        return await child.result()
+
+
+class ChildInput(BaseModel):
+    a: int
+    b: int
+
+
+class StepResponse(BaseModel):
+    status: str
+
+
+@hatchet.workflow(input_validator=ChildInput)
+class Child:
+    @hatchet.step()
+    def process(self, context: Context) -> StepResponse:
+        input = cast(ChildInput, context.workflow_input())
+
+        pretty_print("Workflow Input:", input)  ## This is a `ChildInput`
+
+        return StepResponse(status="success")
+
+    @hatchet.step(parents=["process"])
+    def process2(self, context: Context) -> StepResponse:
+        process_output = cast(StepResponse, context.step_output("process"))
+
+        pretty_print("Process Output:", process_output)  ## This is a `StepResponse`
+
+        return {"status": "step 2 - success"}
+
+    @hatchet.step(parents=["process2"])
+    def process3(self, context: Context) -> StepResponse:
+        process_2_output = cast(StepResponse, context.step_output("process2"))
+
+        pretty_print("Process 2 Output:", process_2_output)  ## This is a `StepResponse`
+
+        return StepResponse(status="step 3 - success")
+
+
+def main():
+    worker = hatchet.worker("pydantic-worker")
+    worker.register_workflow(Parent())
+    worker.register_workflow(Child())
+    worker.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -54,16 +54,10 @@ class ChildTriggerWorkflowOptions(TypedDict):
     sticky: bool | None = None
 
 
-class WorkflowRunDict(TypedDict):
-    workflow_name: str
-    input: Any
-    options: Optional[dict]
-
-
 class ChildWorkflowRunDict(TypedDict):
     workflow_name: str
     input: Any
-    options: ChildTriggerWorkflowOptions[dict]
+    options: ChildTriggerWorkflowOptions
     key: str | None = None
 
 
@@ -71,6 +65,12 @@ class TriggerWorkflowOptions(ScheduleTriggerWorkflowOptions, TypedDict):
     additional_metadata: Dict[str, str] | None = None
     desired_worker_id: str | None = None
     namespace: str | None = None
+
+
+class WorkflowRunDict(TypedDict):
+    workflow_name: str
+    input: Any
+    options: TriggerWorkflowOptions | None
 
 
 class DedupeViolationErr(Exception):
@@ -260,7 +260,9 @@ class AdminClientAioImpl(AdminClientBase):
 
     @tenacity_retry
     async def run_workflows(
-        self, workflows: List[WorkflowRunDict], options: TriggerWorkflowOptions = None
+        self,
+        workflows: list[WorkflowRunDict],
+        options: TriggerWorkflowOptions | None = None,
     ) -> List[WorkflowRunRef]:
         if len(workflows) == 0:
             raise ValueError("No workflows to run")

--- a/hatchet_sdk/clients/dispatcher/action_listener.py
+++ b/hatchet_sdk/clients/dispatcher/action_listener.py
@@ -61,7 +61,7 @@ class Action:
     worker_id: str
     tenant_id: str
     workflow_run_id: str
-    get_group_key_run_id: Optional[str]
+    get_group_key_run_id: str
     job_id: str
     job_name: str
     job_run_id: str

--- a/hatchet_sdk/clients/dispatcher/dispatcher.py
+++ b/hatchet_sdk/clients/dispatcher/dispatcher.py
@@ -137,14 +137,14 @@ class DispatcherClient:
 
         return response
 
-    def release_slot(self, step_run_id: str):
+    def release_slot(self, step_run_id: str) -> None:
         self.client.ReleaseSlot(
             ReleaseSlotRequest(stepRunId=step_run_id),
             timeout=DEFAULT_REGISTER_TIMEOUT,
             metadata=get_metadata(self.token),
         )
 
-    def refresh_timeout(self, step_run_id: str, increment_by: str):
+    def refresh_timeout(self, step_run_id: str, increment_by: str) -> None:
         self.client.RefreshTimeout(
             RefreshTimeoutRequest(
                 stepRunId=step_run_id,

--- a/hatchet_sdk/clients/rest/tenacity_utils.py
+++ b/hatchet_sdk/clients/rest/tenacity_utils.py
@@ -1,10 +1,15 @@
+from typing import Callable, ParamSpec, TypeVar
+
 import grpc
 import tenacity
 
 from hatchet_sdk.logger import logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def tenacity_retry(func):
+
+def tenacity_retry(func: Callable[P, R]) -> Callable[P, R]:
     return tenacity.retry(
         reraise=True,
         wait=tenacity.wait_exponential_jitter(),

--- a/hatchet_sdk/context/context.py
+++ b/hatchet_sdk/context/context.py
@@ -2,7 +2,9 @@ import inspect
 import json
 import traceback
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import List
+from typing import Any, cast
+
+from pydantic import StrictStr
 
 from hatchet_sdk.clients.events import EventClient
 from hatchet_sdk.clients.rest.tenacity_utils import tenacity_retry
@@ -10,8 +12,8 @@ from hatchet_sdk.clients.rest_client import RestApi
 from hatchet_sdk.clients.run_event_listener import RunEventListenerClient
 from hatchet_sdk.clients.workflow_listener import PooledWorkflowRunListener
 from hatchet_sdk.context.worker_context import WorkerContext
-from hatchet_sdk.contracts.dispatcher_pb2 import OverridesData
-from hatchet_sdk.contracts.workflows_pb2 import (
+from hatchet_sdk.contracts.dispatcher_pb2 import OverridesData  # type: ignore
+from hatchet_sdk.contracts.workflows_pb2 import (  # type: ignore[attr-defined]
     BulkTriggerWorkflowRequest,
     TriggerWorkflowRequest,
 )
@@ -24,25 +26,32 @@ from ..clients.admin import (
     TriggerWorkflowOptions,
     WorkflowRunDict,
 )
-from ..clients.dispatcher.dispatcher import Action, DispatcherClient
+from ..clients.dispatcher.dispatcher import (  # type: ignore[attr-defined]
+    Action,
+    DispatcherClient,
+)
 from ..logger import logger
 
 DEFAULT_WORKFLOW_POLLING_INTERVAL = 5  # Seconds
 
 
-def get_caller_file_path():
+def get_caller_file_path() -> str:
     caller_frame = inspect.stack()[2]
 
     return caller_frame.filename
 
 
 class BaseContext:
+
+    action: Action
+    spawn_index: int
+
     def _prepare_workflow_options(
         self,
-        key: str = None,
+        key: str | None = None,
         options: ChildTriggerWorkflowOptions | None = None,
-        worker_id: str = None,
-    ):
+        worker_id: str | None = None,
+    ) -> TriggerWorkflowOptions:
         workflow_run_id = self.action.workflow_run_id
         step_run_id = self.action.step_run_id
 
@@ -54,7 +63,7 @@ class BaseContext:
         if options is not None and "additional_metadata" in options:
             meta = options["additional_metadata"]
 
-        trigger_options: TriggerWorkflowOptions = {
+        trigger_options: TriggerWorkflowOptions = {  # type: ignore[typeddict-item]
             "parent_id": workflow_run_id,
             "parent_step_run_id": step_run_id,
             "child_key": key,
@@ -95,9 +104,9 @@ class ContextAioImpl(BaseContext):
     async def spawn_workflow(
         self,
         workflow_name: str,
-        input: dict = {},
-        key: str = None,
-        options: ChildTriggerWorkflowOptions = None,
+        input: dict[str, Any] = {},
+        key: str | None = None,
+        options: ChildTriggerWorkflowOptions | None = None,
     ) -> WorkflowRunRef:
         worker_id = self.worker.id()
         # if (
@@ -118,15 +127,15 @@ class ContextAioImpl(BaseContext):
 
     @tenacity_retry
     async def spawn_workflows(
-        self, child_workflow_runs: List[ChildWorkflowRunDict]
-    ) -> List[WorkflowRunRef]:
+        self, child_workflow_runs: list[ChildWorkflowRunDict]
+    ) -> list[WorkflowRunRef]:
 
         if len(child_workflow_runs) == 0:
             raise Exception("no child workflows to spawn")
 
         worker_id = self.worker.id()
 
-        bulk_trigger_workflow_runs: WorkflowRunDict = []
+        bulk_trigger_workflow_runs: list[WorkflowRunDict] = []
         for child_workflow_run in child_workflow_runs:
             workflow_name = child_workflow_run["workflow_name"]
             input = child_workflow_run["input"]
@@ -134,7 +143,8 @@ class ContextAioImpl(BaseContext):
             key = child_workflow_run.get("key")
             options = child_workflow_run.get("options", {})
 
-            trigger_options = self._prepare_workflow_options(key, options, worker_id)
+            ## TODO: figure out why this is failing
+            trigger_options = self._prepare_workflow_options(key, options, worker_id)  # type: ignore[arg-type]
 
             bulk_trigger_workflow_runs.append(
                 WorkflowRunDict(
@@ -179,11 +189,11 @@ class Context(BaseContext):
         # Check the type of action.action_payload before attempting to load it as JSON
         if isinstance(action.action_payload, (str, bytes, bytearray)):
             try:
-                self.data = json.loads(action.action_payload)
+                self.data = cast(dict[str, Any], json.loads(action.action_payload))
             except Exception as e:
                 logger.error(f"Error parsing action payload: {e}")
                 # Assign an empty dictionary if parsing fails
-                self.data = {}
+                self.data: dict[str, Any] = {}  # type: ignore[no-redef]
         else:
             # Directly assign the payload to self.data if it's already a dict
             self.data = (
@@ -218,33 +228,34 @@ class Context(BaseContext):
         else:
             self.input = self.data.get("input", {})
 
-    def step_output(self, step: str):
+    def step_output(self, step: str) -> dict[str, Any]:
         try:
-            return self.data["parents"][step]
+            return cast(dict[str, Any], self.data["parents"][step])
         except KeyError:
             raise ValueError(f"Step output for '{step}' not found")
 
     def triggered_by_event(self) -> bool:
-        return self.data.get("triggered_by", "") == "event"
+        return cast(str, self.data.get("triggered_by", "")) == "event"
 
-    def workflow_input(self):
+    def workflow_input(self) -> dict[str, Any]:
         return self.input
 
-    def workflow_run_id(self):
+    def workflow_run_id(self) -> str:
         return self.action.workflow_run_id
 
-    def cancel(self):
+    def cancel(self) -> None:
         logger.debug("cancelling step...")
         self.exit_flag = True
 
     # done returns true if the context has been cancelled
-    def done(self):
+    def done(self) -> bool:
         return self.exit_flag
 
-    def playground(self, name: str, default: str = None):
+    def playground(self, name: str, default: str | None = None) -> str | None:
         # if the key exists in the overrides_data field, return the value
         if name in self.overrides_data:
-            return self.overrides_data[name]
+            ## TODO: Check if this is the right type
+            return cast(str, self.overrides_data[name])
 
         caller_file = get_caller_file_path()
 
@@ -259,7 +270,7 @@ class Context(BaseContext):
 
         return default
 
-    def _log(self, line: str) -> (bool, Exception):  # type: ignore
+    def _log(self, line: str) -> tuple[bool, Exception | None]:
         try:
             self.event_client.log(message=line, step_run_id=self.stepRunId)
             return True, None
@@ -267,7 +278,7 @@ class Context(BaseContext):
             # we don't want to raise an exception here, as it will kill the log thread
             return False, e
 
-    def log(self, line, raise_on_error: bool = False):
+    def log(self, line: Any, raise_on_error: bool = False) -> None:
         if self.stepRunId == "":
             return
 
@@ -277,9 +288,9 @@ class Context(BaseContext):
             except Exception:
                 line = str(line)
 
-        future: Future = self.logger_thread_pool.submit(self._log, line)
+        future = self.logger_thread_pool.submit(self._log, line)
 
-        def handle_result(future: Future):
+        def handle_result(future: Future[tuple[bool, Exception | None]]) -> None:
             success, exception = future.result()
             if not success and exception:
                 if raise_on_error:
@@ -297,22 +308,22 @@ class Context(BaseContext):
 
         future.add_done_callback(handle_result)
 
-    def release_slot(self):
+    def release_slot(self) -> None:
         return self.dispatcher_client.release_slot(self.stepRunId)
 
-    def _put_stream(self, data: str | bytes):
+    def _put_stream(self, data: str | bytes) -> None:
         try:
             self.event_client.stream(data=data, step_run_id=self.stepRunId)
         except Exception as e:
             logger.error(f"Error putting stream event: {e}")
 
-    def put_stream(self, data: str | bytes):
+    def put_stream(self, data: str | bytes) -> None:
         if self.stepRunId == "":
             return
 
         self.stream_event_thread_pool.submit(self._put_stream, data)
 
-    def refresh_timeout(self, increment_by: str):
+    def refresh_timeout(self, increment_by: str) -> None:
         try:
             return self.dispatcher_client.refresh_timeout(
                 step_run_id=self.stepRunId, increment_by=increment_by
@@ -320,28 +331,28 @@ class Context(BaseContext):
         except Exception as e:
             logger.error(f"Error refreshing timeout: {e}")
 
-    def retry_count(self):
+    def retry_count(self) -> int:
         return self.action.retry_count
 
-    def additional_metadata(self):
+    def additional_metadata(self) -> dict[str, Any] | None:
         return self.action.additional_metadata
 
-    def child_index(self):
+    def child_index(self) -> int | None:
         return self.action.child_workflow_index
 
-    def child_key(self):
+    def child_key(self) -> str | None:
         return self.action.child_workflow_key
 
-    def parent_workflow_run_id(self):
+    def parent_workflow_run_id(self) -> str | None:
         return self.action.parent_workflow_run_id
 
-    def fetch_run_failures(self):
+    def fetch_run_failures(self) -> list[dict[str, StrictStr]]:
         data = self.rest_client.workflow_run_get(self.action.workflow_run_id)
         other_job_runs = [
-            run for run in data.job_runs if run.job_id != self.action.job_id
+            run for run in (data.job_runs or []) if run.job_id != self.action.job_id
         ]
         # TODO: Parse Step Runs using a Pydantic Model rather than a hand crafted dictionary
-        failed_step_runs = [
+        return [
             {
                 "step_id": step_run.step_id,
                 "step_run_action_name": step_run.step.action,
@@ -350,7 +361,5 @@ class Context(BaseContext):
             for job_run in other_job_runs
             if job_run.step_runs
             for step_run in job_run.step_runs
-            if step_run.error
+            if step_run.error and step_run.step
         ]
-
-        return failed_step_runs

--- a/hatchet_sdk/context/worker_context.py
+++ b/hatchet_sdk/context/worker_context.py
@@ -21,7 +21,7 @@ class WorkerContext:
         await self.client.async_upsert_worker_labels(self._worker_id, labels)
         self._labels.update(labels)
 
-    def id(self):
+    def id(self) -> str:
         return self._worker_id
 
     # def has_workflow(self, workflow_name: str):

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional, Type, TypeVar, cast, get_type_hints
 
+from pydantic import BaseModel
 from typing_extensions import deprecated
 
 from hatchet_sdk.clients.rest_client import RestApi
@@ -34,6 +35,8 @@ from .workflow import (
     WorkflowStepProtocol,
 )
 
+T = TypeVar("T", bound=BaseModel)
+
 
 def workflow(
     name: str = "",
@@ -45,6 +48,7 @@ def workflow(
     sticky: StickyStrategy = None,
     default_priority: int | None = None,
     concurrency: ConcurrencyExpression | None = None,
+    input_validator: Type[T] | None = None,
 ) -> Callable[[Type[WorkflowInterface]], WorkflowMeta]:
     on_events = on_events or []
     on_crons = on_crons or []
@@ -63,6 +67,7 @@ def workflow(
         # with WorkflowMeta as its metaclass
 
         ## TODO: Figure out how to type this metaclass correctly
+        cls.input_validator = input_validator
         return WorkflowMeta(cls.name, cls.__bases__, dict(cls.__dict__))
 
     return inner

--- a/hatchet_sdk/hatchet.py
+++ b/hatchet_sdk/hatchet.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Callable, Optional, ParamSpec, TypeVar
+from typing import Any, Callable, Optional, ParamSpec, Type, TypeVar
 
 from typing_extensions import deprecated
 
@@ -27,14 +27,13 @@ from .clients.events import EventClient
 from .clients.run_event_listener import RunEventListenerClient
 from .logger import logger
 from .worker.worker import Worker
-from .workflow import ConcurrencyExpression, WorkflowMeta
+from .workflow import ConcurrencyExpression, WorkflowInterface, WorkflowMeta
 
 P = ParamSpec("P")
 R = TypeVar("R")
 
 
-## TODO: Fix return type here to properly type hint the metaclass
-def workflow(  # type: ignore[no-untyped-def]
+def workflow(
     name: str = "",
     on_events: list[str] | None = None,
     on_crons: list[str] | None = None,
@@ -44,7 +43,7 @@ def workflow(  # type: ignore[no-untyped-def]
     sticky: StickyStrategy = None,
     default_priority: int | None = None,
     concurrency: ConcurrencyExpression | None = None,
-):
+) -> Callable[[type], Type[WorkflowInterface]]:
     on_events = on_events or []
     on_crons = on_crons or []
 
@@ -62,9 +61,10 @@ def workflow(  # type: ignore[no-untyped-def]
         # with WorkflowMeta as its metaclass
 
         ## TODO: Figure out how to type this metaclass correctly
-        return WorkflowMeta(cls.name, cls.__bases__, dict(cls.__dict__))  # type: ignore[no-untyped-call]
+        return WorkflowMeta(cls.name, cls.__bases__, dict(cls.__dict__))
 
-    return inner
+    ## TODO: Figure out how to type this return correctly
+    return inner  # type: ignore[return-value]
 
 
 def step(

--- a/hatchet_sdk/utils/backoff.py
+++ b/hatchet_sdk/utils/backoff.py
@@ -2,7 +2,7 @@ import asyncio
 import random
 
 
-async def exp_backoff_sleep(attempt: int, max_sleep_time: float = 5):
+async def exp_backoff_sleep(attempt: int, max_sleep_time: float = 5) -> None:
     base_time = 0.1  # starting sleep time in seconds (100 milliseconds)
     jitter = random.uniform(0, base_time)  # add random jitter
     sleep_time = min(base_time * (2**attempt) + jitter, max_sleep_time)

--- a/hatchet_sdk/utils/serialization.py
+++ b/hatchet_sdk/utils/serialization.py
@@ -2,7 +2,10 @@ from typing import Any
 
 
 def flatten(xs: dict[str, Any], parent_key: str, separator: str) -> dict[str, Any]:
-    items = []
+    if not xs:
+        return {}
+
+    items: list[tuple[str, Any]] = []
 
     for k, v in xs.items():
         new_key = parent_key + separator + k if parent_key else k

--- a/hatchet_sdk/utils/tracing.py
+++ b/hatchet_sdk/utils/tracing.py
@@ -59,7 +59,10 @@ def inject_carrier_into_metadata(
     return metadata
 
 
-def parse_carrier_from_metadata(metadata: dict[str, Any]) -> Context:
+def parse_carrier_from_metadata(metadata: dict[str, Any] | None) -> Context | None:
+    if not metadata:
+        return None
+
     return (
         TraceContextTextMapPropagator().extract(_ctx)
         if (_ctx := metadata.get(OTEL_CARRIER_KEY))

--- a/hatchet_sdk/utils/tracing.py
+++ b/hatchet_sdk/utils/tracing.py
@@ -6,9 +6,9 @@ from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import Tracer, TracerProvider
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace import NoOpTracerProvider
+from opentelemetry.trace import NoOpTracerProvider, Tracer
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from hatchet_sdk.loader import ClientConfig
@@ -44,7 +44,7 @@ def create_tracer(config: ClientConfig) -> Tracer:
 
 
 def create_carrier() -> dict[str, str]:
-    carrier = {}
+    carrier: dict[str, str] = {}
     TraceContextTextMapPropagator().inject(carrier)
 
     return carrier

--- a/hatchet_sdk/utils/types.py
+++ b/hatchet_sdk/utils/types.py
@@ -1,0 +1,8 @@
+from typing import Type
+
+from pydantic import BaseModel
+
+
+class WorkflowValidator(BaseModel):
+    workflow_input: Type[BaseModel] | None = None
+    step_output: Type[BaseModel] | None = None

--- a/hatchet_sdk/utils/typing.py
+++ b/hatchet_sdk/utils/typing.py
@@ -1,0 +1,9 @@
+from typing import Any, Type, TypeGuard, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def is_basemodel_subclass(model: Any) -> bool:
+    return isinstance(model, type) and issubclass(model, BaseModel)

--- a/hatchet_sdk/v2/callable.py
+++ b/hatchet_sdk/v2/callable.py
@@ -42,6 +42,7 @@ class HatchetCallable(Generic[T]):
         default_priority: int | None = None,
     ):
         self.func = func
+        self.validators = func.validators
 
         on_events = on_events or []
         on_crons = on_crons or []

--- a/hatchet_sdk/worker/action_listener_process.py
+++ b/hatchet_sdk/worker/action_listener_process.py
@@ -87,15 +87,13 @@ class WorkerActionListenerProcess:
         try:
             self.dispatcher_client = new_dispatcher(self.config)
 
-            self.listener: ActionListener = (
-                await self.dispatcher_client.get_action_listener(
-                    GetActionListenerRequest(
-                        worker_name=self.name,
-                        services=["default"],
-                        actions=self.actions,
-                        max_runs=self.max_runs,
-                        _labels=self.labels,
-                    )
+            self.listener = await self.dispatcher_client.get_action_listener(
+                GetActionListenerRequest(
+                    worker_name=self.name,
+                    services=["default"],
+                    actions=self.actions,
+                    max_runs=self.max_runs,
+                    _labels=self.labels,
                 )
             )
 

--- a/hatchet_sdk/worker/runner/run_loop_manager.py
+++ b/hatchet_sdk/worker/runner/run_loop_manager.py
@@ -2,22 +2,27 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from multiprocessing import Queue
-from typing import Any, Callable, Dict
+from typing import Callable, TypeVar
 
+from hatchet_sdk import Context
 from hatchet_sdk.client import Client, new_client_raw
 from hatchet_sdk.clients.dispatcher.action_listener import Action
 from hatchet_sdk.loader import ClientConfig
 from hatchet_sdk.logger import logger
+from hatchet_sdk.utils.types import WorkflowValidator
 from hatchet_sdk.worker.runner.runner import Runner
 from hatchet_sdk.worker.runner.utils.capture_logs import capture_logs
 
 STOP_LOOP = "STOP_LOOP"
 
+T = TypeVar("T")
+
 
 @dataclass
 class WorkerActionRunLoopManager:
     name: str
-    action_registry: Dict[str, Callable[..., Any]]
+    action_registry: dict[str, Callable[[Context], T]]
+    validator_registry: dict[str, WorkflowValidator]
     max_runs: int | None
     config: ClientConfig
     action_queue: Queue
@@ -71,6 +76,7 @@ class WorkerActionRunLoopManager:
             self.max_runs,
             self.handle_kill,
             self.action_registry,
+            self.validator_registry,
             self.config,
             self.labels,
         )

--- a/hatchet_sdk/worker/runner/runner.py
+++ b/hatchet_sdk/worker/runner/runner.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from multiprocessing import Queue
 from threading import Thread, current_thread
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, TypeVar, cast
 
 from opentelemetry.trace import StatusCode
 
@@ -18,9 +18,9 @@ from hatchet_sdk.clients.dispatcher.action_listener import Action
 from hatchet_sdk.clients.dispatcher.dispatcher import new_dispatcher
 from hatchet_sdk.clients.run_event_listener import new_listener
 from hatchet_sdk.clients.workflow_listener import PooledWorkflowRunListener
-from hatchet_sdk.context import Context
+from hatchet_sdk.context import Context  # type: ignore[attr-defined]
 from hatchet_sdk.context.worker_context import WorkerContext
-from hatchet_sdk.contracts.dispatcher_pb2 import (
+from hatchet_sdk.contracts.dispatcher_pb2 import (  # type: ignore[attr-defined]
     GROUP_KEY_EVENT_TYPE_COMPLETED,
     GROUP_KEY_EVENT_TYPE_FAILED,
     GROUP_KEY_EVENT_TYPE_STARTED,
@@ -48,11 +48,11 @@ class Runner:
     def __init__(
         self,
         name: str,
-        event_queue: Queue,
+        event_queue: "Queue[Any]",
         max_runs: int | None = None,
         handle_kill: bool = True,
         action_registry: dict[str, Callable[..., Any]] = {},
-        config: ClientConfig = {},
+        config: ClientConfig = ClientConfig(),
         labels: dict[str, str | int] = {},
     ):
         # We store the config so we can dynamically create clients for the dispatcher client.
@@ -60,7 +60,7 @@ class Runner:
         self.client = new_client_raw(config)
         self.name = self.client.config.namespace + name
         self.max_runs = max_runs
-        self.tasks: Dict[str, asyncio.Task] = {}  # Store run ids and futures
+        self.tasks: Dict[str, asyncio.Task[Any]] = {}  # Store run ids and futures
         self.contexts: Dict[str, Context] = {}  # Store run ids and contexts
         self.action_registry: dict[str, Callable[..., Any]] = action_registry
 
@@ -89,7 +89,7 @@ class Runner:
     def create_workflow_run_url(self, action: Action) -> str:
         return f"{self.config.server_url}/workflow-runs/{action.workflow_run_id}?tenant={action.tenant_id}"
 
-    def run(self, action: Action):
+    def run(self, action: Action) -> None:
         ctx = parse_carrier_from_metadata(action.additional_metadata)
 
         with self.otel_tracer.start_as_current_span(
@@ -122,8 +122,8 @@ class Runner:
                     span.add_event(log)
                     logger.error(log)
 
-    def step_run_callback(self, action: Action):
-        def inner_callback(task: asyncio.Task):
+    def step_run_callback(self, action: Action) -> Callable[[asyncio.Task[Any]], None]:
+        def inner_callback(task: asyncio.Task[Any]) -> None:
             self.cleanup_run_id(action.step_run_id)
 
             errored = False
@@ -164,8 +164,10 @@ class Runner:
 
         return inner_callback
 
-    def group_key_run_callback(self, action: Action):
-        def inner_callback(task: asyncio.Task):
+    def group_key_run_callback(
+        self, action: Action
+    ) -> Callable[[asyncio.Task[Any]], None]:
+        def inner_callback(task: asyncio.Task[Any]) -> None:
             self.cleanup_run_id(action.get_group_key_run_id)
 
             errored = False
@@ -204,7 +206,10 @@ class Runner:
 
         return inner_callback
 
-    def thread_action_func(self, context, action_func, action: Action):
+    ## TODO: Stricter type hinting here
+    def thread_action_func(
+        self, context: Context, action_func: Callable[..., Any], action: Action
+    ) -> Any:
         if action.step_run_id is not None and action.step_run_id != "":
             self.threads[action.step_run_id] = current_thread()
         elif (
@@ -215,10 +220,15 @@ class Runner:
 
         return action_func(context)
 
+    ## TODO: Stricter type hinting here
     # We wrap all actions in an async func
     async def async_wrapped_action_func(
-        self, context: Context, action_func, action: Action, run_id: str
-    ):
+        self,
+        context: Context,
+        action_func: Callable[..., Any],
+        action: Action,
+        run_id: str,
+    ) -> Any:
         wr.set(context.workflow_run_id())
         sr.set(context.step_run_id)
 
@@ -254,7 +264,7 @@ class Runner:
         finally:
             self.cleanup_run_id(run_id)
 
-    def cleanup_run_id(self, run_id: str):
+    def cleanup_run_id(self, run_id: str | None) -> None:
         if run_id in self.tasks:
             del self.tasks[run_id]
 
@@ -267,7 +277,7 @@ class Runner:
     def create_context(
         self, action: Action, action_func: Callable[..., Any] | None
     ) -> Context | DurableContext:
-        if hasattr(action_func, "durable") and action_func.durable:
+        if hasattr(action_func, "durable") and getattr(action_func, "durable"):
             return DurableContext(
                 action,
                 self.dispatcher_client,
@@ -292,7 +302,7 @@ class Runner:
             self.client.config.namespace,
         )
 
-    async def handle_start_step_run(self, action: Action):
+    async def handle_start_step_run(self, action: Action) -> None:
         with self.otel_tracer.start_as_current_span(
             f"hatchet.worker.handle_start_step_run.{action.step_id}",
         ) as span:
@@ -336,7 +346,7 @@ class Runner:
 
             span.add_event("Finished step run")
 
-    async def handle_start_group_key_run(self, action: Action):
+    async def handle_start_group_key_run(self, action: Action) -> None:
         with self.otel_tracer.start_as_current_span(
             f"hatchet.worker.handle_start_step_run.{action.step_id}"
         ) as span:
@@ -353,6 +363,7 @@ class Runner:
                 self.worker_context,
                 self.client.config.namespace,
             )
+
             self.contexts[action.get_group_key_run_id] = context
 
             # Find the corresponding action function from the registry
@@ -387,18 +398,18 @@ class Runner:
 
             span.add_event("Finished group key run")
 
-    def force_kill_thread(self, thread):
+    def force_kill_thread(self, thread: Thread) -> None:
         """Terminate a python threading.Thread."""
         try:
             if not thread.is_alive():
                 return
 
-            logger.info(f"Forcefully terminating thread {thread.ident}")
+            ident = cast(int, thread.ident)
+
+            logger.info(f"Forcefully terminating thread {ident}")
 
             exc = ctypes.py_object(SystemExit)
-            res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                ctypes.c_long(thread.ident), exc
-            )
+            res = ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(ident), exc)
             if res == 0:
                 raise ValueError("Invalid thread ID")
             elif res != 1:
@@ -408,7 +419,7 @@ class Runner:
                 ctypes.pythonapi.PyThreadState_SetAsyncExc(thread.ident, 0)
                 raise SystemError("PyThreadState_SetAsyncExc failed")
 
-            logger.info(f"Successfully terminated thread {thread.ident}")
+            logger.info(f"Successfully terminated thread {ident}")
 
             # Immediately add a new thread to the thread pool, because we've actually killed a worker
             # in the ThreadPoolExecutor
@@ -416,7 +427,7 @@ class Runner:
         except Exception as e:
             logger.exception(f"Failed to terminate thread: {e}")
 
-    async def handle_cancel_action(self, run_id: str):
+    async def handle_cancel_action(self, run_id: str) -> None:
         with self.otel_tracer.start_as_current_span(
             "hatchet.worker.handle_cancel_action"
         ) as span:
@@ -427,7 +438,9 @@ class Runner:
                 # call cancel to signal the context to stop
                 if run_id in self.contexts:
                     context = self.contexts.get(run_id)
-                    context.cancel()
+
+                    if context:
+                        context.cancel()
 
                 await asyncio.sleep(1)
 
@@ -458,7 +471,7 @@ class Runner:
                 output_bytes = str(output)
         return output_bytes
 
-    async def wait_for_tasks(self):
+    async def wait_for_tasks(self) -> None:
         running = len(self.tasks.keys())
         while running > 0:
             logger.info(f"waiting for {running} tasks to finish...")
@@ -466,6 +479,6 @@ class Runner:
             running = len(self.tasks.keys())
 
 
-def errorWithTraceback(message: str, e: Exception):
+def errorWithTraceback(message: str, e: Exception) -> str:
     trace = "".join(traceback.format_exception(type(e), e, e.__traceback__))
     return f"{message}\n{trace}"

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -70,8 +70,8 @@ class Worker:
 
         self.ctx = multiprocessing.get_context("spawn")
 
-        self.action_queue: Queue[Any] = self.ctx.Queue()
-        self.event_queue: Queue[Any] = self.ctx.Queue()
+        self.action_queue: "Queue[Any]" = self.ctx.Queue()
+        self.event_queue: "Queue[Any]" = self.ctx.Queue()
 
         self.loop: asyncio.AbstractEventLoop
 

--- a/hatchet_sdk/workflow.py
+++ b/hatchet_sdk/workflow.py
@@ -1,5 +1,7 @@
 import functools
-from typing import Any, Callable, Protocol, Type, TypeVar, Union, cast
+from typing import Any, Callable, Protocol, Type, TypeVar, Union, cast, get_type_hints
+
+from pydantic import BaseModel
 
 from hatchet_sdk import ConcurrencyLimitStrategy
 from hatchet_sdk.contracts.workflows_pb2 import (  # type: ignore[attr-defined]
@@ -11,6 +13,7 @@ from hatchet_sdk.contracts.workflows_pb2 import (  # type: ignore[attr-defined]
     WorkflowKind,
 )
 from hatchet_sdk.logger import logger
+from hatchet_sdk.utils.typing import is_basemodel_subclass
 
 
 class WorkflowStepProtocol(Protocol):
@@ -82,6 +85,7 @@ class WorkflowInterface(Protocol):
     sticky: Union[StickyStrategy.Value, None]
     default_priority: int | None
     concurrency_expression: ConcurrencyExpression | None
+    input_validator: Type[BaseModel] | None
 
 
 class WorkflowMeta(type):
@@ -100,6 +104,7 @@ class WorkflowMeta(type):
 
         concurrencyActions = _create_steps_actions_list("_concurrency_fn_name")
         steps = _create_steps_actions_list("_step_name")
+
         onFailureSteps = _create_steps_actions_list("_on_failure_step_name")
 
         # Define __init__ and get_step_order methods

--- a/hatchet_sdk/workflow.py
+++ b/hatchet_sdk/workflow.py
@@ -24,6 +24,8 @@ class WorkflowStepProtocol(Protocol):
     _step_retries: int | None
     _step_rate_limits: list[str] | None
     _step_desired_worker_labels: dict[str, str]
+    _step_backoff_factor: float | None
+    _step_backoff_max_seconds: int | None
 
     _concurrency_fn_name: str
     _concurrency_max_runs: int | None
@@ -33,6 +35,8 @@ class WorkflowStepProtocol(Protocol):
     _on_failure_step_timeout: str | None
     _on_failure_step_retries: int
     _on_failure_step_rate_limits: list[str] | None
+    _on_failure_step_backoff_factor: float | None
+    _on_failure_step_backoff_max_seconds: int | None
 
 
 StepsType = list[tuple[str, WorkflowStepProtocol]]

--- a/hatchet_sdk/workflow.py
+++ b/hatchet_sdk/workflow.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, List, Protocol, Tuple, Type
 
 from hatchet_sdk import ConcurrencyLimitStrategy
 from hatchet_sdk.contracts.workflows_pb2 import (
@@ -35,8 +35,16 @@ class ConcurrencyExpression:
         self.limit_strategy = limit_strategy
 
 
+class WorkflowInterface(Protocol):
+    def get_name(self, namespace: str) -> str: ...
+
+    def get_actions(self, namespace: str) -> list[tuple[str, Callable[..., Any]]]: ...
+
+    def get_create_opts(self, namespace: str) -> Any: ...
+
+
 class WorkflowMeta(type):
-    def __new__(cls, name, bases, attrs):
+    def __new__(cls, name, bases, attrs) -> Type[WorkflowInterface]:
         concurrencyActions: stepsType = [
             (getattr(func, "_concurrency_fn_name"), attrs.pop(func_name))
             for func_name, func in list(attrs.items())

--- a/lint.sh
+++ b/lint.sh
@@ -1,3 +1,3 @@
-poetry run black . --check --color
+poetry run black . --color
 poetry run isort .
 poetry run mypy --config-file=pyproject.toml

--- a/lint.sh
+++ b/lint.sh
@@ -1,1 +1,3 @@
-pre-commit run --all-files || pre-commit run --all-files
+poetry run black . --check --color
+poetry run isort .
+poetry run mypy --config-file=pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.42.0"
+version = "0.42.1"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ extend_exclude = "hatchet_sdk/contracts/"
 [tool.mypy]
 strict = true
 files = ["hatchet_sdk/hatchet.py", "hatchet_sdk/worker/worker.py"]
+exclude = "^examples/*"
 follow_imports = "silent"
 disable_error_code = ["unused-coroutine"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,11 @@ files = [
   "hatchet_sdk/worker/worker.py",
   "hatchet_sdk/context/context.py",
   "hatchet_sdk/worker/runner/runner.py",
-  "hatchet_sdk/workflow.py"
+  "hatchet_sdk/workflow.py",
+  "hatchet_sdk/utils/serialization.py",
+  "hatchet_sdk/utils/tracing.py",
+  "hatchet_sdk/utils/types.py",
+  "hatchet_sdk/utils/backoff.py"
 ]
 exclude = "^examples/*"
 follow_imports = "silent"
@@ -101,3 +105,4 @@ blocked = "examples.blocked_async.worker:main"
 existing_loop = "examples.worker_existing_loop.worker:main"
 bulk_fanout = "examples.bulk_fanout.worker:main"
 retries_with_backoff = "examples.retries_with_backoff.worker:main"
+pydantic = "examples.pydantic.worker:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,13 @@ extend_exclude = "hatchet_sdk/contracts/"
 
 [tool.mypy]
 strict = true
-files = ["hatchet_sdk/hatchet.py", "hatchet_sdk/worker/worker.py"]
+files = [
+  "hatchet_sdk/hatchet.py",
+  "hatchet_sdk/worker/worker.py",
+  "hatchet_sdk/context/context.py",
+  "hatchet_sdk/worker/runner/runner.py",
+  "hatchet_sdk/workflow.py"
+]
 exclude = "^examples/*"
 follow_imports = "silent"
 disable_error_code = ["unused-coroutine"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,9 @@ extend_exclude = "hatchet_sdk/contracts/"
 
 [tool.mypy]
 strict = true
-files = ["hatchet_sdk/hatchet.py"]
+files = ["hatchet_sdk/hatchet.py", "hatchet_sdk/worker/worker.py"]
 follow_imports = "silent"
+disable_error_code = ["unused-coroutine"]
 
 [tool.poetry.scripts]
 api = "examples.api.api:main"


### PR DESCRIPTION
A couple things here:

* AFAICT, `Worker` doesn't need to be a `dataclass`, and this was making things a bit more complicated (b/c of `post_init`, etc.)
* Added `hatchet_sdk/worker/worker.py` to the included MyPy paths and fixed all the type hints (except for a couple tricky ones with the `WorkflowMeta` metaclass - we can handle those later
* Replaced some dynamically set attributes with `setattr` to make the type checker happy
* Added a `Protocol` for the `WorkflowMeta` metaclass for the same reason
* Fixes for `Workflow` metaclass and `Context`

Will try to annotate!