### PR TITLE
Feat: Worker Health Checks

### DIFF
--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -165,7 +165,12 @@ class ConfigLoader:
             "otel_exporter_oltp_protocol", "HATCHET_CLIENT_OTEL_EXPORTER_OTLP_PROTOCOL"
         )
 
-        worker_healthcheck_port = int(get_config_value("worker_healthcheck_port", "HATCHET_CLIENT_WORKER_HEALTHCHECK_PORT") or 8001)
+        worker_healthcheck_port = int(
+            get_config_value(
+                "worker_healthcheck_port", "HATCHET_CLIENT_WORKER_HEALTHCHECK_PORT"
+            )
+            or 8001
+        )
 
         return ClientConfig(
             tenant_id=tenant_id,
@@ -182,7 +187,7 @@ class ConfigLoader:
             otel_service_name=otel_service_name,
             otel_exporter_oltp_headers=otel_exporter_oltp_headers,
             otel_exporter_oltp_protocol=otel_exporter_oltp_protocol,
-            worker_healthcheck_port=worker_healthcheck_port
+            worker_healthcheck_port=worker_healthcheck_port,
         )
 
     def _load_tls_config(self, tls_data: Dict, host_port) -> ClientTLSConfig:

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -43,6 +43,7 @@ class ClientConfig:
         otel_service_name: str | None = None,
         otel_exporter_oltp_headers: dict[str, str] | None = None,
         otel_exporter_oltp_protocol: str | None = None,
+        worker_healthcheck_port: int | None = None,
     ):
         self.tenant_id = tenant_id
         self.tls_config = tls_config
@@ -57,6 +58,7 @@ class ClientConfig:
         self.otel_service_name = otel_service_name
         self.otel_exporter_oltp_headers = otel_exporter_oltp_headers
         self.otel_exporter_oltp_protocol = otel_exporter_oltp_protocol
+        self.worker_healthcheck_port = worker_healthcheck_port
 
         if not self.logInterceptor:
             self.logInterceptor = getLogger()
@@ -163,6 +165,8 @@ class ConfigLoader:
             "otel_exporter_oltp_protocol", "HATCHET_CLIENT_OTEL_EXPORTER_OTLP_PROTOCOL"
         )
 
+        worker_healthcheck_port = int(get_config_value("worker_healthcheck_port", "HATCHET_CLIENT_WORKER_HEALTHCHECK_PORT") or 8001)
+
         return ClientConfig(
             tenant_id=tenant_id,
             tls_config=tls_config,
@@ -178,6 +182,7 @@ class ConfigLoader:
             otel_service_name=otel_service_name,
             otel_exporter_oltp_headers=otel_exporter_oltp_headers,
             otel_exporter_oltp_protocol=otel_exporter_oltp_protocol,
+            worker_healthcheck_port=worker_healthcheck_port
         )
 
     def _load_tls_config(self, tls_data: Dict, host_port) -> ClientTLSConfig:

--- a/hatchet_sdk/loader.py
+++ b/hatchet_sdk/loader.py
@@ -44,6 +44,7 @@ class ClientConfig:
         otel_exporter_oltp_headers: dict[str, str] | None = None,
         otel_exporter_oltp_protocol: str | None = None,
         worker_healthcheck_port: int | None = None,
+        worker_healthcheck_enabled: bool | None = None,
     ):
         self.tenant_id = tenant_id
         self.tls_config = tls_config
@@ -59,6 +60,7 @@ class ClientConfig:
         self.otel_exporter_oltp_headers = otel_exporter_oltp_headers
         self.otel_exporter_oltp_protocol = otel_exporter_oltp_protocol
         self.worker_healthcheck_port = worker_healthcheck_port
+        self.worker_healthcheck_enabled = worker_healthcheck_enabled
 
         if not self.logInterceptor:
             self.logInterceptor = getLogger()
@@ -172,6 +174,16 @@ class ConfigLoader:
             or 8001
         )
 
+        worker_healthcheck_enabled = (
+            str(
+                get_config_value(
+                    "worker_healthcheck_port",
+                    "HATCHET_CLIENT_WORKER_HEALTHCHECK_ENABLED",
+                )
+            )
+            == "True"
+        )
+
         return ClientConfig(
             tenant_id=tenant_id,
             tls_config=tls_config,
@@ -188,6 +200,7 @@ class ConfigLoader:
             otel_exporter_oltp_headers=otel_exporter_oltp_headers,
             otel_exporter_oltp_protocol=otel_exporter_oltp_protocol,
             worker_healthcheck_port=worker_healthcheck_port,
+            worker_healthcheck_enabled=worker_healthcheck_enabled,
         )
 
     def _load_tls_config(self, tls_data: Dict, host_port) -> ClientTLSConfig:

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -168,6 +168,8 @@ class Worker:
         return web.json_response({"status": status.name})
 
     async def metrics_handler(self, request: Request) -> Response:
+        self.worker_status_gauge.set(1 if self.status() == WorkerStatus.HEALTHY else 0)
+
         return web.Response(body=generate_latest(), content_type="text/plain")
 
     async def start_health_server(self) -> None:

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -168,7 +168,7 @@ class Worker:
         return web.json_response({"status": status.name})
 
     async def metrics_handler(self, request: Request) -> Response:
-        self.worker_status_gauge.set(1 if self.status() == WorkerStatus.HEALTHY else 0)
+        self.worker_status_gauge.set(1 if self.status() == WorkerStatus.HEALTHY else -1)
 
         return web.Response(body=generate_latest(), content_type="text/plain")
 

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -236,7 +236,8 @@ class Worker:
         if not _from_start:
             self.setup_loop(options.loop)
 
-        await self.start_health_server()
+        if self.config.worker_healthcheck_enabled:
+            await self.start_health_server()
 
         self.action_listener_process = self._start_listener()
 

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -168,7 +168,7 @@ class Worker:
         return web.json_response({"status": status.name})
 
     async def metrics_handler(self, request: Request) -> Response:
-        self.worker_status_gauge.set(1 if self.status() == WorkerStatus.HEALTHY else -1)
+        self.worker_status_gauge.set(1 if self.status() == WorkerStatus.HEALTHY else 0)
 
         return web.Response(body=generate_latest(), content_type="text/plain")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1207,6 +1207,20 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "prometheus-client"
+version = "0.21.1"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "prometheus_client-0.21.1-py3-none-any.whl", hash = "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301"},
+    {file = "prometheus_client-0.21.1.tar.gz", hash = "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "propcache"
 version = "0.2.1"
 description = "Accelerated property cache"
@@ -1976,4 +1990,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cf3e677f24e93174e09a2fbfbbe19a869ec35764b8f8634943eaad3484874321"
+content-hash = "f3ae3a18cf8e872454be02dd86fcdf3defd9e7010ce31d2cc3b03d3447dea78a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.42.5"
+version = "0.43.0"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ opentelemetry-instrumentation = "^0.48b0"
 opentelemetry-distro = "^0.48b0"
 opentelemetry-exporter-otlp = "^1.27.0"
 opentelemetry-exporter-otlp-proto-http = "^1.27.0"
+prometheus-client = "^0.21.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"


### PR DESCRIPTION
Adding a simple server to handle worker health checks using `aiohttp` running on a customizable port w/ a default.

Example requests:

`/health` (basic usage)

```bash
hatchet-sdk-py3.10matt@Mac hatchet-python % curl localhost:8001/health 
{"status": "HEALTHY"}%   
```

`/metrics` (Prometheus)

```bash
hatchet-sdk-py3.10matt@Mac hatchet-python % curl localhost:8001/metrics
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 18641.0
python_gc_objects_collected_total{generation="1"} 4788.0
python_gc_objects_collected_total{generation="2"} 215.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 308.0
python_gc_collections_total{generation="1"} 27.0
python_gc_collections_total{generation="2"} 2.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="10",patchlevel="15",version="3.10.15"} 1.0
# HELP hatchet_worker_status Current status of the Hatchet worker
# TYPE hatchet_worker_status gauge
hatchet_worker_status 0.0
```

Custom port:

```bash
hatchet-sdk-py3.10matt@Mac hatchet-python % HATCHET_CLIENT_WORKER_HEALTHCHECK_PORT=1234 pr simple
[DEBUG] 🪓 -- 2024-12-20 12:57:44,666 - creating new event loop
[INFO]  🪓 -- 2024-12-20 12:57:44,666 - ------------------------------------------
[INFO]  🪓 -- 2024-12-20 12:57:44,666 - STARTING HATCHET...
[DEBUG] 🪓 -- 2024-12-20 12:57:44,666 - worker runtime starting on PID: 15420
[INFO]  🪓 -- 2024-12-20 12:57:44,666 - healthcheck server running on port 1234
```

Already taken port:

```bash
hatchet-sdk-py3.10matt@Mac hatchet-python % HATCHET_CLIENT_WORKER_HEALTHCHECK_PORT=8080 pr simple
[DEBUG] 🪓 -- 2024-12-20 12:58:36,081 - creating new event loop
[INFO]  🪓 -- 2024-12-20 12:58:36,081 - ------------------------------------------
[INFO]  🪓 -- 2024-12-20 12:58:36,081 - STARTING HATCHET...
[DEBUG] 🪓 -- 2024-12-20 12:58:36,081 - worker runtime starting on PID: 15639
[ERROR] 🪓 -- 2024-12-20 12:58:36,081 - failed to start healthcheck server
[ERROR] 🪓 -- 2024-12-20 12:58:36,081 - [Errno 48] error while attempting to bind on address ('0.0.0.0', 8080): address already in use
[DEBUG] 🪓 -- 2024-12-20 12:58:36,083 - action listener starting on PID: 15650
[INFO]  🪓 -- 2024-12-20 12:58:36,085 - starting runner...
```

Example graph from local prometheus (starting up, shutting down, and starting up again):

<img width="1728" alt="Screenshot 2024-12-20 at 3 45 13 PM" src="https://github.com/user-attachments/assets/fdfaf956-7c43-4934-ab9c-a72c140bf347" />
