### PR TITLE
Fix Tenacity Retry Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 openapitools.json
+.python-version

--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -252,7 +252,7 @@ class AdminClientAioImpl(AdminClientBase):
                     workflow_listener=self.pooled_workflow_listener,
                     workflow_run_event_listener=self.listener_client,
                 )
-            except grpc.RpcError as e:
+            except (grpc.RpcError, grpc.aio.AioRpcError) as e:
                 if e.code() == grpc.StatusCode.ALREADY_EXISTS:
                     raise DedupeViolationErr(e.details())
 

--- a/hatchet_sdk/clients/events.py
+++ b/hatchet_sdk/clients/events.py
@@ -125,10 +125,7 @@ class EventClient:
 
             span.add_event("Pushing event", attributes={"key": namespaced_event_key})
 
-            try:
-                return self.client.Push(request, metadata=get_metadata(self.token))
-            except grpc.RpcError as e:
-                raise ValueError(f"gRPC error: {e}")
+            return self.client.Push(request, metadata=get_metadata(self.token))
 
     @tenacity_retry
     def bulk_push(
@@ -188,13 +185,9 @@ class EventClient:
         bulk_request = BulkPushEventRequest(events=bulk_events)
 
         span.add_event("Pushing bulk events")
-        try:
-            response = self.client.BulkPush(
-                bulk_request, metadata=get_metadata(self.token)
-            )
-            return response.events
-        except grpc.RpcError as e:
-            raise ValueError(f"gRPC error: {e}")
+        response = self.client.BulkPush(bulk_request, metadata=get_metadata(self.token))
+
+        return response.events
 
     def log(self, message: str, step_run_id: str):
         try:

--- a/hatchet_sdk/clients/rest/tenacity_utils.py
+++ b/hatchet_sdk/clients/rest/tenacity_utils.py
@@ -28,8 +28,8 @@ def tenacity_alert_retry(retry_state: tenacity.RetryCallState) -> None:
 
 
 def tenacity_should_retry(ex: Exception) -> bool:
-    if isinstance(ex, grpc.aio.AioRpcError):
-        if ex.code in [
+    if isinstance(ex, (grpc.aio.AioRpcError, grpc.RpcError)):
+        if ex.code() in [
             grpc.StatusCode.UNIMPLEMENTED,
             grpc.StatusCode.NOT_FOUND,
         ]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.43.2"
+version = "0.43.3"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
### [Review with whitespace hidden, the diff is much smaller than GH thinks](https://github.com/hatchet-dev/hatchet-python/pull/298/files?diff=unified&w=1)

Fixing Tenacity logic for retries here - there were a couple of issues:

1. It's not super clear to me when `grpc` will raise a `grpc.RpcError` vs when it will raise `grpc.aio.AioRpcError` (I'd think that when using `aio` methods it'd raise an `aio` error, but from local testing that appears to not be the case. So I just am catching both cases everywhere for now.
2. We were catching these RPC errors and re-raising value errors in a number of places, which would cause the `isinstance(ex, (grpc.aio.AioRpcError, grpc.RpcError))` check to fail, making the errors fall through and not be retried. In those cases, I removed the error handling in the function that had retries enabled (cc @grutt lmk if there's a reason I'm missing for doing this - want to make sure I'm not breaking something unintentionally)
3. `ex.code` is a method, so the `if ex.code in [...]` check would always be falsy regardless of the code, so I fixed that