### PR TITLE
Fix: Create Schedule Workflow Pydantic Key Error 

### DIFF
--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -284,7 +284,7 @@ class AsyncRestApi:
         return await self.workflow_run_api.scheduled_workflow_run_create(
             tenant=self.tenant_id,
             workflow=name,
-            create_schedule_workflow_trigger_request=ScheduleWorkflowRunRequest(
+            schedule_workflow_run_request=ScheduleWorkflowRunRequest(
                 triggerAt=trigger_at,
                 input=input,
                 additional_metadata=additional_metadata,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.44.1"
+version = "0.44.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Fixing error
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for scheduled_workflow_run_create
schedule_workflow_run_request
  Missing required argument [type=missing_argument, input_value=ArgsKwargs((<hatchet_sdk....atetime.timezone.utc))}), input_type=ArgsKwargs]
    For further information visit https://errors.pydantic.dev/2.9/v/missing_argument
create_schedule_workflow_trigger_request
  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=ScheduleWorkflowRunReques...=datetime.timezone.utc)), input_type=ScheduleWorkflowRunRequest]
    For further information visit https://errors.pydantic.dev/2.9/v/unexpected_keyword_argument
```

Context: https://discord.com/channels/1088927970518909068/1331373228161237013
Related: https://github.com/hatchet-dev/hatchet-python/pull/300