### PR TITLE
Proposal: Remove `aio_client` from admin client

### DIFF
--- a/hatchet_sdk/clients/admin.py
+++ b/hatchet_sdk/clients/admin.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 from datetime import datetime
-from functools import partial
 from typing import Any, Callable, Dict, List, Optional, TypedDict, TypeVar, Union
 
 import grpc


### PR DESCRIPTION
The `aio_client` on the `AdminClient` seems to just have a bunch of duped code that replaces the original gRPC client with the async one, which also causes problems when using `asyncio.run` (or other cases with existing event loops, like in Pytest). Proposal here is to replace it with a call to `asyncio.to_thread` on the sync methods like we do in the event client.