### PR TITLE
Fix: workflow run failure due to use of invalid signal(SIGQUIT) on Windows Machines

### DIFF
--- a/hatchet_sdk/worker/action_listener_process.py
+++ b/hatchet_sdk/worker/action_listener_process.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import logging
 import signal
@@ -73,8 +74,11 @@ class WorkerActionListenerProcess:
         loop = asyncio.get_event_loop()
         loop.add_signal_handler(signal.SIGINT, noop_handler)
         loop.add_signal_handler(signal.SIGTERM, noop_handler)
+        
+        sig_force_quit = "SIGBREAK" if os.name == "nt" else "SIGQUIT" # Windows doesn't have SIGQUIT
+        sig_force_quit_signal = getattr(signal, sig_force_quit, None)
         loop.add_signal_handler(
-            signal.SIGQUIT, lambda: asyncio.create_task(self.exit_gracefully())
+           sig_force_quit_signal, lambda: asyncio.create_task(self.exit_gracefully())
         )
 
     async def start(self, retry_attempt=0):

--- a/hatchet_sdk/worker/worker.py
+++ b/hatchet_sdk/worker/worker.py
@@ -314,7 +314,10 @@ class Worker:
     def _setup_signal_handlers(self) -> None:
         signal.signal(signal.SIGTERM, self._handle_exit_signal)
         signal.signal(signal.SIGINT, self._handle_exit_signal)
-        signal.signal(signal.SIGQUIT, self._handle_force_quit_signal)
+        
+        sig_force_quit = "SIGBREAK" if os.name == "nt" else "SIGQUIT" # Windows doesn't have SIGQUIT
+        sig_force_quit_signal = getattr(signal, sig_force_quit, None)
+        signal.signal(sig_force_quit_signal, self._handle_force_quit_signal)
 
     def _handle_exit_signal(self, signum: int, frame: FrameType | None) -> None:
         sig_name = "SIGTERM" if signum == signal.SIGTERM else "SIGINT"


### PR DESCRIPTION
`signal.SIGQUIT` is not available in Windows machines, causing Worker setup failures. 
As a fix, replaced signal.SIGQUIT with signal.SIGBREAK if the user machine is windows. 

closes #308 

Reference: https://docs.python.org/3/library/signal.html#signal.signal