### PR TITLE
Fix: More OTel Cleanup

### DIFF
--- a/examples/opentelemetry_instrumentation/test_otel_instrumentation.py
+++ b/examples/opentelemetry_instrumentation/test_otel_instrumentation.py
@@ -21,7 +21,7 @@ tracer = trace_provider.get_tracer(__name__)
 
 
 def create_additional_metadata() -> dict[str, str]:
-    return inject_traceparent_into_metadata({"hello": "world"}, create_traceparent())
+    return inject_traceparent_into_metadata({"hello": "world"})
 
 
 def create_push_options() -> PushEventOptions:

--- a/examples/opentelemetry_instrumentation/test_otel_instrumentation.py
+++ b/examples/opentelemetry_instrumentation/test_otel_instrumentation.py
@@ -6,7 +6,11 @@ from opentelemetry.trace import NoOpTracerProvider
 from hatchet_sdk import Hatchet, Worker
 from hatchet_sdk.clients.admin import TriggerWorkflowOptions
 from hatchet_sdk.clients.events import PushEventOptions
-from hatchet_sdk.opentelemetry.instrumentor import HatchetInstrumentor
+from hatchet_sdk.opentelemetry.instrumentor import (
+    HatchetInstrumentor,
+    create_traceparent,
+    inject_traceparent_into_metadata,
+)
 
 trace_provider = NoOpTracerProvider()
 
@@ -17,9 +21,7 @@ tracer = trace_provider.get_tracer(__name__)
 
 
 def create_additional_metadata() -> dict[str, str]:
-    return instrumentor.inject_traceparent_into_metadata(
-        {"hello": "world"}, instrumentor.create_traceparent()
-    )
+    return inject_traceparent_into_metadata({"hello": "world"}, create_traceparent())
 
 
 def create_push_options() -> PushEventOptions:

--- a/examples/opentelemetry_instrumentation/triggers.py
+++ b/examples/opentelemetry_instrumentation/triggers.py
@@ -4,16 +4,18 @@ from examples.opentelemetry_instrumentation.client import hatchet
 from examples.opentelemetry_instrumentation.tracer import trace_provider
 from hatchet_sdk.clients.admin import TriggerWorkflowOptions
 from hatchet_sdk.clients.events import PushEventOptions
-from hatchet_sdk.opentelemetry.instrumentor import HatchetInstrumentor
+from hatchet_sdk.opentelemetry.instrumentor import (
+    HatchetInstrumentor,
+    create_traceparent,
+    inject_traceparent_into_metadata,
+)
 
 instrumentor = HatchetInstrumentor(tracer_provider=trace_provider)
 tracer = trace_provider.get_tracer(__name__)
 
 
 def create_additional_metadata() -> dict[str, str]:
-    return instrumentor.inject_traceparent_into_metadata(
-        {"hello": "world"}, instrumentor.create_traceparent()
-    )
+    return inject_traceparent_into_metadata({"hello": "world"}, create_traceparent())
 
 
 def create_push_options() -> PushEventOptions:

--- a/examples/opentelemetry_instrumentation/triggers.py
+++ b/examples/opentelemetry_instrumentation/triggers.py
@@ -15,7 +15,7 @@ tracer = trace_provider.get_tracer(__name__)
 
 
 def create_additional_metadata() -> dict[str, str]:
-    return inject_traceparent_into_metadata({"hello": "world"}, create_traceparent())
+    return inject_traceparent_into_metadata({"hello": "world"})
 
 
 def create_push_options() -> PushEventOptions:

--- a/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/hatchet_sdk/opentelemetry/instrumentor.py
@@ -47,6 +47,19 @@ OTEL_TRACEPARENT_KEY = "traceparent"
 
 
 def create_traceparent() -> str | None:
+    """
+    Creates and returns a W3C traceparent header value using OpenTelemetry's context propagation.
+
+    The traceparent header is used to propagate context information across service boundaries
+    in distributed tracing systems. It follows the W3C Trace Context specification.
+
+    Returns:
+        str | None: A W3C-formatted traceparent header value if successful, None if the context
+                    injection fails or no active span exists.
+
+                    Example: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    """
+
     carrier: dict[str, str] = {}
     TraceContextTextMapPropagator().inject(carrier)
 
@@ -54,6 +67,21 @@ def create_traceparent() -> str | None:
 
 
 def parse_carrier_from_metadata(metadata: dict[str, str] | None) -> Context | None:
+    """
+    Parses OpenTelemetry trace context from metadata dictionary.
+    This function extracts the trace context from metadata using the W3C Trace Context format,
+    specifically looking for the traceparent header.
+    Args:
+        metadata (dict[str, str] | None): A dictionary containing metadata key-value pairs,
+            potentially including the traceparent header. Can be None.
+    Returns:
+        Context | None: The extracted OpenTelemetry Context object if a valid traceparent
+            is found in the metadata, None otherwise.
+    Example:
+        >>> metadata = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}
+        >>> context = parse_carrier_from_metadata(metadata)
+    """
+
     if not metadata:
         return None
 
@@ -68,6 +96,21 @@ def parse_carrier_from_metadata(metadata: dict[str, str] | None) -> Context | No
 def inject_traceparent_into_metadata(
     metadata: dict[str, str], traceparent: str | None = None
 ) -> dict[str, str]:
+    """
+    Injects OpenTelemetry traceparent into metadata dictionary.
+    This function takes a metadata dictionary and an optional traceparent string,
+    and returns a new metadata dictionary with the traceparent added under the
+    OTEL_TRACEPARENT_KEY. If no traceparent is provided, it attempts to create one.
+
+    Args:
+        metadata (dict[str, str]): The metadata dictionary to inject the traceparent into
+        traceparent (str | None, optional): The traceparent string to inject. If None,
+            will attempt to use the current span. Defaults to None.
+    Returns:
+        dict[str, str]: A new metadata dictionary containing the original metadata plus
+            the injected traceparent if one was available or could be created.
+    """
+
     if not traceparent:
         traceparent = create_traceparent()
 

--- a/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/hatchet_sdk/opentelemetry/instrumentor.py
@@ -79,9 +79,10 @@ def parse_carrier_from_metadata(metadata: dict[str, str] | None) -> Context | No
               is found in the metadata, otherwise None.
     :rtype: Context | None
 
-    :example:
-        >>> metadata = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}
-        >>> context = parse_carrier_from_metadata(metadata)
+    :Example:
+
+    >>> metadata = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}
+    >>> context = parse_carrier_from_metadata(metadata)
     """
 
     if not metadata:

--- a/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/hatchet_sdk/opentelemetry/instrumentor.py
@@ -53,11 +53,10 @@ def create_traceparent() -> str | None:
     The traceparent header is used to propagate context information across service boundaries
     in distributed tracing systems. It follows the W3C Trace Context specification.
 
-    Returns:
-        str | None: A W3C-formatted traceparent header value if successful, None if the context
-                    injection fails or no active span exists.
-
-                    Example: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+    :returns: A W3C-formatted traceparent header value if successful, None if the context
+                    injection fails or no active span exists.\n
+                    Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+    :rtype: str | None:
     """
 
     carrier: dict[str, str] = {}
@@ -68,16 +67,19 @@ def create_traceparent() -> str | None:
 
 def parse_carrier_from_metadata(metadata: dict[str, str] | None) -> Context | None:
     """
-    Parses OpenTelemetry trace context from metadata dictionary.
-    This function extracts the trace context from metadata using the W3C Trace Context format,
-    specifically looking for the traceparent header.
-    Args:
-        metadata (dict[str, str] | None): A dictionary containing metadata key-value pairs,
-            potentially including the traceparent header. Can be None.
-    Returns:
-        Context | None: The extracted OpenTelemetry Context object if a valid traceparent
-            is found in the metadata, None otherwise.
-    Example:
+    Parses OpenTelemetry trace context from a metadata dictionary.
+
+    Extracts the trace context from metadata using the W3C Trace Context format,
+    specifically looking for the `traceparent` header.
+
+    :param metadata: A dictionary containing metadata key-value pairs,
+                     potentially including the `traceparent` header. Can be None.
+    :type metadata: dict[str, str] | None
+    :returns: The extracted OpenTelemetry Context object if a valid `traceparent`
+              is found in the metadata, otherwise None.
+    :rtype: Context | None
+
+    :example:
         >>> metadata = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}
         >>> context = parse_carrier_from_metadata(metadata)
     """
@@ -97,18 +99,27 @@ def inject_traceparent_into_metadata(
     metadata: dict[str, str], traceparent: str | None = None
 ) -> dict[str, str]:
     """
-    Injects OpenTelemetry traceparent into metadata dictionary.
-    This function takes a metadata dictionary and an optional traceparent string,
-    and returns a new metadata dictionary with the traceparent added under the
-    OTEL_TRACEPARENT_KEY. If no traceparent is provided, it attempts to create one.
+    Injects OpenTelemetry `traceparent` into a metadata dictionary.
 
-    Args:
-        metadata (dict[str, str]): The metadata dictionary to inject the traceparent into
-        traceparent (str | None, optional): The traceparent string to inject. If None,
-            will attempt to use the current span. Defaults to None.
-    Returns:
-        dict[str, str]: A new metadata dictionary containing the original metadata plus
-            the injected traceparent if one was available or could be created.
+    Takes a metadata dictionary and an optional `traceparent` string,
+    returning a new metadata dictionary with the `traceparent` added under the
+    `OTEL_TRACEPARENT_KEY`. If no `traceparent` is provided, it attempts to create one.
+
+    :param metadata: The metadata dictionary to inject the `traceparent` into.
+    :type metadata: dict[str, str]
+    :param traceparent: The `traceparent` string to inject. If None, attempts to use
+                        the current span.
+    :type traceparent: str | None, optional
+    :returns: A new metadata dictionary containing the original metadata plus
+              the injected `traceparent`, if one was available or could be created.
+    :rtype: dict[str, str]
+
+    :Example:
+
+    >>> metadata = {"key": "value"}
+    >>> new_metadata = inject_traceparent(metadata, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+    >>> print(new_metadata)
+    {"key": "value", "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}
     """
 
     if not traceparent:

--- a/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/hatchet_sdk/opentelemetry/instrumentor.py
@@ -66,12 +66,18 @@ def parse_carrier_from_metadata(metadata: dict[str, str] | None) -> Context | No
 
 
 def inject_traceparent_into_metadata(
-    metadata: dict[str, str], traceparent: str | None
+    metadata: dict[str, str], traceparent: str | None = None
 ) -> dict[str, str]:
-    if traceparent:
-        metadata[OTEL_TRACEPARENT_KEY] = traceparent
+    if not traceparent:
+        traceparent = create_traceparent()
 
-    return metadata
+    if not traceparent:
+        return metadata
+
+    return {
+        **metadata,
+        OTEL_TRACEPARENT_KEY: traceparent,
+    }
 
 
 class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]

--- a/hatchet_sdk/opentelemetry/instrumentor.py
+++ b/hatchet_sdk/opentelemetry/instrumentor.py
@@ -142,6 +142,18 @@ class HatchetInstrumentor(BaseInstrumentor):  # type: ignore[misc]
         tracer_provider: TracerProvider | None = None,
         meter_provider: MeterProvider | None = None,
     ):
+        """
+        Hatchet OpenTelemetry instrumentor.
+
+        The instrumentor provides an OpenTelemetry integration for Hatchet by setting up
+        tracing and metrics collection.
+
+        :param tracer_provider: TracerProvider | None: The OpenTelemetry TracerProvider to use.
+                If not provided, the global tracer provider will be used.
+        :param meter_provider: MeterProvider | None: The OpenTelemetry MeterProvider to use.
+                If not provided, a no-op meter provider will be used.
+        """
+
         self.tracer_provider = tracer_provider or get_tracer_provider()
         self.meter_provider = meter_provider or NoOpMeterProvider()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.46.1"
+version = "0.46.2"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
#### [Review without whitespace](https://github.com/hatchet-dev/hatchet-python/pull/319/files?diff=unified&w=1)

Fixing a couple more OTel things:

1. Exporting helpers outside of the instrumentor instance
2. Docs
3. Defaulting to current span if no parent is specified