### PR TITLE
Fix: Pause Work Assignment on Exit

### DIFF
--- a/hatchet_sdk/clients/rest_client.py
+++ b/hatchet_sdk/clients/rest_client.py
@@ -9,6 +9,7 @@ from pydantic import StrictInt
 from hatchet_sdk.clients.rest.api.event_api import EventApi
 from hatchet_sdk.clients.rest.api.log_api import LogApi
 from hatchet_sdk.clients.rest.api.step_run_api import StepRunApi
+from hatchet_sdk.clients.rest.api.worker_api import WorkerApi
 from hatchet_sdk.clients.rest.api.workflow_api import WorkflowApi
 from hatchet_sdk.clients.rest.api.workflow_run_api import WorkflowRunApi
 from hatchet_sdk.clients.rest.api.workflow_runs_api import WorkflowRunsApi
@@ -83,6 +84,7 @@ class AsyncRestApi:
         self._step_run_api = None
         self._event_api = None
         self._log_api = None
+        self._worker_api: WorkerApi | None = None
 
     @property
     def api_client(self):
@@ -101,6 +103,13 @@ class AsyncRestApi:
         if self._workflow_run_api is None:
             self._workflow_run_api = WorkflowRunApi(self.api_client)
         return self._workflow_run_api
+
+    @property
+    def worker_api(self):
+        if self._worker_api is None:
+            self._worker_api = WorkerApi(self.api_client)
+
+        return self._worker_api
 
     @property
     def step_run_api(self):

--- a/hatchet_sdk/worker/action_listener_process.py
+++ b/hatchet_sdk/worker/action_listener_process.py
@@ -42,6 +42,7 @@ BLOCKED_THREAD_WARNING = (
     "THE TIME TO START THE STEP RUN IS TOO LONG, THE MAIN THREAD MAY BE BLOCKED"
 )
 
+
 @dataclass
 class WorkerActionListenerProcess:
     name: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hatchet-sdk"
-version = "0.47.0"
+version = "0.47.1"
 description = ""
 authors = ["Alexander Belanger <alexander@hatchet.run>"]
 readme = "README.md"


### PR DESCRIPTION
Pausing assignment of work to the worker when we get an exit signal